### PR TITLE
Fix: 파일 경로 변경으로 인한 import 상대 경로 관련 에러 및 mountDomNode 타입 에러 해결

### DIFF
--- a/src/components/Common/Logo.jsx
+++ b/src/components/Common/Logo.jsx
@@ -1,6 +1,6 @@
 import { useLocation } from "react-router-dom";
 
-import Button from "./UI/Button";
+import Button from "../UI/Button";
 import PropTypes from "prop-types";
 
 const Logo = ({ styles, type, destination }) => {

--- a/src/components/Common/Portal.jsx
+++ b/src/components/Common/Portal.jsx
@@ -10,5 +10,5 @@ export default Portal;
 
 Portal.propTypes = {
   children: PropTypes.node.isRequired,
-  mountDomNode: PropTypes.object.isRequired,
+  mountDomNode: PropTypes.objectOf(PropTypes.element).isRequired,
 };

--- a/src/components/Common/Portal.jsx
+++ b/src/components/Common/Portal.jsx
@@ -10,5 +10,5 @@ export default Portal;
 
 Portal.propTypes = {
   children: PropTypes.node.isRequired,
-  mountDomNode: PropTypes.node.isRequired,
+  mountDomNode: PropTypes.object.isRequired,
 };


### PR DESCRIPTION
## 상세 설명

- Logo 컴포넌트의 파일 경로 이동으로 인한 Logo 컴포넌트 내부 import 상대경로에서 에러가 나고 있었습니다. 미처 해당 부분에 대한 확인을 못했어서 바로 hotfix하게 되었습니다.
- Portal 컴포넌트의 mountDomNode prop 타입 에러에 대해 해결하였습니다.
![image](https://github.com/user-attachments/assets/f340a21d-7c93-4be3-b57f-1085e6f83861)


## 참고사항

- 반성합니다. 앞으로 두 번 세 번 체크하고 merge 하도록 하겠습니다.

## PR 체크 사항

- [x] conflict를 모두 해결하였습니다.
- [x] 가장 최신 dev 브랜치를 pull 하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] `console.log`나 주석 여부를 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
- [x] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!

## 리뷰 반영사항

-

## PR 리뷰 마감시간

- 5분 이내