### PR TITLE
Feat: 서버 API와의 연결 및 로직/에러핸들링 최적화 (무한스크롤, 로그인, 유저 그룹 리스트, 키워드 등록)

### DIFF
--- a/src/api/group/asyncGetUserGroup.js
+++ b/src/api/group/asyncGetUserGroup.js
@@ -1,9 +1,9 @@
 import fetchHandler from "..";
 import { BASE_URL } from "../../config/constants";
 
-const asyncGetUserGroup = async (userId) => {
+const asyncGetUserGroup = async (userUid) => {
   const fetchInfo = {
-    url: `${BASE_URL}/groups/${userId}`,
+    url: `${BASE_URL}/groups/${userUid}`,
     params: "",
   };
 

--- a/src/api/post/asyncGetPosts.js
+++ b/src/api/post/asyncGetPosts.js
@@ -1,5 +1,5 @@
 import fetchHandler from "..";
-import { BASE_URL, POST_LISTS } from "../../config/const";
+import { BASE_URL, POST_LISTS } from "../../config/constants";
 
 const asyncGetPosts = async (
   cursorId = POST_LISTS.CURSOR_ID,

--- a/src/api/post/asyncGetPosts.js
+++ b/src/api/post/asyncGetPosts.js
@@ -1,0 +1,22 @@
+import fetchHandler from "..";
+import { BASE_URL, POST_LISTS } from "../../config/const";
+
+const asyncGetPosts = async (
+  keywordId,
+  {
+    includedKeyword = POST_LISTS.DEFAULT_INCLUDED_KEYWORD,
+    limit = POST_LISTS.LIMIT,
+    cursorId = POST_LISTS.CURSOR_ID,
+  }
+) => {
+  const fetchInfo = {
+    url: `${BASE_URL}/posts/${keywordId}`,
+    params: `?includedKeyword=${includedKeyword}&limit=${limit}&cursorId=${cursorId}`,
+  };
+
+  const response = await fetchHandler(fetchInfo);
+
+  return response;
+};
+
+export default asyncGetPosts;

--- a/src/api/post/asyncGetPosts.js
+++ b/src/api/post/asyncGetPosts.js
@@ -2,12 +2,8 @@ import fetchHandler from "..";
 import { BASE_URL, POST_LISTS } from "../../config/const";
 
 const asyncGetPosts = async (
-  keywordId,
-  {
-    includedKeyword = POST_LISTS.DEFAULT_INCLUDED_KEYWORD,
-    limit = POST_LISTS.LIMIT,
-    cursorId = POST_LISTS.CURSOR_ID,
-  }
+  cursorId = POST_LISTS.CURSOR_ID,
+  { keywordId, includedKeyword = POST_LISTS.DEFAULT_INCLUDED_KEYWORD, limit = POST_LISTS.LIMIT }
 ) => {
   const fetchInfo = {
     url: `${BASE_URL}/posts/${keywordId}`,

--- a/src/api/post/asyncGetPosts.js
+++ b/src/api/post/asyncGetPosts.js
@@ -2,8 +2,12 @@ import fetchHandler from "..";
 import { BASE_URL, POST_LISTS } from "../../config/constants";
 
 const asyncGetPosts = async (
-  cursorId = POST_LISTS.CURSOR_ID,
-  { keywordId, includedKeyword = POST_LISTS.DEFAULT_INCLUDED_KEYWORD, limit = POST_LISTS.LIMIT }
+  cursorId = POST_LISTS.DEFAULT_CURSOR_ID,
+  {
+    keywordId,
+    includedKeyword = POST_LISTS.DEFAULT_INCLUDED_KEYWORD,
+    limit = POST_LISTS.DEFAULT_LIMIT,
+  }
 ) => {
   const fetchInfo = {
     url: `${BASE_URL}/posts/${keywordId}`,

--- a/src/components/Button/SignInButton.jsx
+++ b/src/components/Button/SignInButton.jsx
@@ -15,7 +15,6 @@ const SignInButton = () => {
   const signOut = useBoundStore((state) => state.signOut);
   const setIsSignIn = useBoundStore((state) => state.setIsSignIn);
   const setUserInfo = useBoundStore((state) => state.setUserInfo);
-  const setServerSignInError = useBoundStore((state) => state.setServerSignInError);
   const openModalTypeList = useBoundStore((state) => state.openModalTypeList);
   const googleSignInError = useBoundStore((state) => state.error.googleSignInError);
   const addModal = useBoundStore((state) => state.addModal);
@@ -47,8 +46,8 @@ const SignInButton = () => {
             setUserInfo({ uid, email, displayName, photoURL });
             navigate("/myPage");
           },
-          onError: ({ message }) => {
-            setServerSignInError(message);
+          onError: () => {
+            addModal(MODAL_TYPE.ERROR);
           },
         }
       );

--- a/src/components/Card/Post/PostCard.jsx
+++ b/src/components/Card/Post/PostCard.jsx
@@ -4,16 +4,16 @@ import changeDayFormat from "../../../utils/changeDayFormat";
 import getDate from "../../../utils/getDate";
 import PropTypes from "prop-types";
 
-const PostCard = ({ postTitle, postContent, likeCount, commentCount, link, createdAt }) => {
+const PostCard = ({ postTitle, postDescription, likeCount, commentCount, link, createdAt }) => {
   const createdDate = getDate(createdAt);
 
   return (
-    <div className="flex flex-col items-start justify-center gap-5 w-full border-3 border-rose-200/80 bg-white rounded-[30px] px-25 py-15 hover:border-4">
+    <div className="flex flex-col items-start justify-center gap-5 w-full border-3 border-rose-200/80 bg-white rounded-[30px] px-25 py-15">
       <p className="flex items-center gap-10">
         <span className="text-purple-700 text-22 font-bold">{postTitle}</span>
       </p>
       <p className="flex items-center gap-10 mb-15">
-        <span className="text-purple-500 text-16">{postContent}</span>
+        <span className="text-purple-500 text-16">{postDescription}</span>
       </p>
       <div className="flex justify-between items-center w-full">
         <p className="flex items-center gap-10">
@@ -41,7 +41,7 @@ export default PostCard;
 
 PostCard.propTypes = {
   postTitle: PropTypes.string.isRequired,
-  postContent: PropTypes.string.isRequired,
+  postDescription: PropTypes.string.isRequired,
   likeCount: PropTypes.number.isRequired,
   commentCount: PropTypes.number.isRequired,
   link: PropTypes.string.isRequired,

--- a/src/components/Card/Post/PostCard.jsx
+++ b/src/components/Card/Post/PostCard.jsx
@@ -26,7 +26,9 @@ const PostCard = ({ postTitle, postDescription, likeCount, commentCount, link, c
             <span className="text-rose-500"> {commentCount}</span>
           </span>
           <span className="text-rose-400/80 text-14">
-            {`${createdDate.currentYear}년 ${createdDate.currentMonth}월 ${createdDate.currentDate}일 ${changeDayFormat(createdDate.currentDay)} ${createdDate.currentHour}시 ${createdDate.currentMinute}분`}
+            {createdDate.currentYear}년 {createdDate.currentMonth}월 {createdDate.currentDate}일{" "}
+            {changeDayFormat(createdDate.currentDay)} {createdDate.currentHour}시{" "}
+            {createdDate.currentMinute}분
           </span>
         </p>
         <Link to={link} target="_blank" rel="noopener">

--- a/src/components/Card/Post/PostCard.jsx
+++ b/src/components/Card/Post/PostCard.jsx
@@ -1,0 +1,5 @@
+const PostCard = () => {
+  return;
+};
+
+export default PostCard;

--- a/src/components/Card/Post/PostCard.jsx
+++ b/src/components/Card/Post/PostCard.jsx
@@ -1,5 +1,49 @@
-const PostCard = () => {
-  return;
+import { Link } from "react-router-dom";
+
+import changeDayFormat from "../../../utils/changeDayFormat";
+import getDate from "../../../utils/getDate";
+import PropTypes from "prop-types";
+
+const PostCard = ({ postTitle, postContent, likeCount, commentCount, link, createdAt }) => {
+  const createdDate = getDate(createdAt);
+
+  return (
+    <div className="flex flex-col items-start justify-center gap-3 w-full border-2 border-rose-200/80 bg-white rounded-[30px] px-20 py-10">
+      <p className="flex items-center gap-10">
+        <span className="text-purple-500/80 text-18">{postTitle}</span>
+      </p>
+      <p className="flex items-center gap-10">
+        <span className="text-purple-400/80 text-16">{postContent}</span>
+      </p>
+      <p className="flex justify-between items-center">
+        <p className="flex items-center gap-10">
+          <span className="text-rose-400/80 text-14">
+            좋아요
+            <span className="text-rose-400"> {likeCount}</span>
+          </span>
+          <span className="text-rose-400/80 text-14">
+            댓글수
+            <span className="text-rose-400"> {commentCount}</span>
+          </span>
+          <span className="text-rose-400/80 text-14">
+            {`${createdDate.currentYear}년 ${createdDate.currentMonth}월 ${createdDate.currentDate}일 ${changeDayFormat(createdDate.currentDay)} ${createdDate.currentHour}시 ${createdDate.currentMinute}분`}
+          </span>
+        </p>
+        <Link to={link} target="_blank" rel="noopener">
+          <span className="text-pink-200 text-14">블로그 바로가기</span>
+        </Link>
+      </p>
+    </div>
+  );
 };
 
 export default PostCard;
+
+PostCard.propTypes = {
+  postTitle: PropTypes.string.isRequired,
+  postContent: PropTypes.string.isRequired,
+  likeCount: PropTypes.number.isRequired,
+  commentCount: PropTypes.number.isRequired,
+  link: PropTypes.number.isRequired,
+  createdAt: PropTypes.string.isRequired,
+};

--- a/src/components/Card/Post/PostCard.jsx
+++ b/src/components/Card/Post/PostCard.jsx
@@ -8,31 +8,31 @@ const PostCard = ({ postTitle, postContent, likeCount, commentCount, link, creat
   const createdDate = getDate(createdAt);
 
   return (
-    <div className="flex flex-col items-start justify-center gap-3 w-full border-2 border-rose-200/80 bg-white rounded-[30px] px-20 py-10">
+    <div className="flex flex-col items-start justify-center gap-5 w-full border-3 border-rose-200/80 bg-white rounded-[30px] px-25 py-15 hover:border-4">
       <p className="flex items-center gap-10">
-        <span className="text-purple-500/80 text-18">{postTitle}</span>
+        <span className="text-purple-700 text-22 font-bold">{postTitle}</span>
       </p>
-      <p className="flex items-center gap-10">
-        <span className="text-purple-400/80 text-16">{postContent}</span>
+      <p className="flex items-center gap-10 mb-15">
+        <span className="text-purple-500 text-16">{postContent}</span>
       </p>
-      <p className="flex justify-between items-center">
+      <div className="flex justify-between items-center w-full">
         <p className="flex items-center gap-10">
           <span className="text-rose-400/80 text-14">
             좋아요
-            <span className="text-rose-400"> {likeCount}</span>
+            <span className="text-rose-500"> {likeCount}</span>
           </span>
           <span className="text-rose-400/80 text-14">
             댓글수
-            <span className="text-rose-400"> {commentCount}</span>
+            <span className="text-rose-500"> {commentCount}</span>
           </span>
           <span className="text-rose-400/80 text-14">
             {`${createdDate.currentYear}년 ${createdDate.currentMonth}월 ${createdDate.currentDate}일 ${changeDayFormat(createdDate.currentDay)} ${createdDate.currentHour}시 ${createdDate.currentMinute}분`}
           </span>
         </p>
         <Link to={link} target="_blank" rel="noopener">
-          <span className="text-pink-200 text-14">블로그 바로가기</span>
+          <span className="text-pink-400 text-14">👉 블로그 바로가기</span>
         </Link>
-      </p>
+      </div>
     </div>
   );
 };
@@ -44,6 +44,6 @@ PostCard.propTypes = {
   postContent: PropTypes.string.isRequired,
   likeCount: PropTypes.number.isRequired,
   commentCount: PropTypes.number.isRequired,
-  link: PropTypes.number.isRequired,
+  link: PropTypes.string.isRequired,
   createdAt: PropTypes.string.isRequired,
 };

--- a/src/components/Card/Post/PostCardList.jsx
+++ b/src/components/Card/Post/PostCardList.jsx
@@ -2,7 +2,10 @@ import { useRef } from "react";
 import { useParams } from "react-router-dom";
 
 import asyncGetPosts from "../../../api/post/asyncGetPosts";
+import { ERROR_MESSAGE } from "../../../config/constants";
 import useInfiniteData from "../../../hooks/useInfiniteData";
+import Error from "../../UI/Error";
+import Loading from "../../UI/Loading";
 import PostCard from "./PostCard";
 
 const PostCardList = () => {
@@ -11,12 +14,12 @@ const PostCardList = () => {
   const observeRootRef = useRef(null);
 
   const infiniteDataArgument = {
-    queryKey: ["allPosts", keywordId],
+    queryKey: ["posts", keywordId],
     queryFn: asyncGetPosts,
     options: {
       keywordId,
       includedKeyword: "",
-      limit: 10,
+      limit: 5,
     },
     initialPageParam: "",
     getNextPageParam: (lastPage) => (lastPage.hasNext ? lastPage.nextCursorId : undefined),
@@ -24,58 +27,39 @@ const PostCardList = () => {
     root: observeRootRef.current,
   };
 
-  useInfiniteData(infiniteDataArgument);
+  const { data: postResponse, isPending } = useInfiniteData(infiniteDataArgument);
 
-  const postResponse = {
-    items: [
-      {
-        id: "9625dbd0-66e3-42fe-8084-88fa6a180a25",
-        link: "https://blog.naver.com/krystarline/223075913585",
-        title: "무엇보다 '바닐라코딩'을 선택한 이유",
-        content: "네이버 검색창에 바닐라코딩을 입력하니~~~!",
-        commentCount: 5,
-        likeCount: 10,
-        score: 50,
-        isAd: false,
-        createdAt: "2024-11-01T04:33:01.579Z",
-        updatedAt: "2024-11-01T04:33:01.579Z",
-      },
-      {
-        id: "9625dbd0-66e3-42fe-8084-88fa6a180a26",
-        link: "https://blog.naver.com/krystarline/223075913585",
-        title: "무엇보다 '바닐라코딩'을 선택한 이유2",
-        content: "네이버 검색창에 바닐라코딩을 입력하니2~~~!",
-        commentCount: 1,
-        likeCount: 9,
-        score: 80,
-        isAd: true,
-        createdAt: "2024-11-01T04:33:01.579Z",
-        updatedAt: "2024-11-01T04:33:01.579Z",
-      },
-    ],
-    nextCursorId: "234f34wfj8934j0j40gj",
-    hasNext: true,
-  };
+  if (postResponse?.pages[0]?.message?.includes("Error occured")) {
+    return <Error errorMessage={ERROR_MESSAGE.FETCH_POSTS} />;
+  }
 
   return (
     <article
       ref={observeRootRef}
       className="flex flex-col justify-start gap-12 bg-white border-4 border-pink-100 rounded-[10px] pt-25 px-30 w-full h-full flex-grow overflow-y-scroll"
     >
-      {postResponse?.items?.map((postInfo) => {
-        return (
-          <PostCard
-            key={postInfo?.id}
-            postTitle={postInfo?.title}
-            postContent={postInfo?.content}
-            likeCount={postInfo?.likeCount}
-            commentCount={postInfo?.commentCount}
-            link={postInfo?.link}
-            createdAt={postInfo?.createdAt}
-          />
-        );
-      })}
-      <div className="w-full h-40" ref={observeRef}></div>
+      {isPending ? (
+        <Loading width={100} height={100} text={""} />
+      ) : postResponse?.pages[0]?.items?.length === 0 ? (
+        <p>해당 키워드에 대한 블로그가 없습니다.</p>
+      ) : (
+        postResponse?.pages?.map((page) => {
+          return page.items?.map((postInfo) => {
+            return (
+              <PostCard
+                key={postInfo?._id}
+                postTitle={postInfo?.title}
+                postDescription={postInfo?.description}
+                likeCount={postInfo?.likeCount}
+                commentCount={postInfo?.commentCount}
+                link={postInfo?.link}
+                createdAt={postInfo?.createdAt}
+              />
+            );
+          });
+        })
+      )}
+      <div className="w-full h-10 flex-shrink-0" ref={observeRef} />
     </article>
   );
 };

--- a/src/components/Card/Post/PostCardList.jsx
+++ b/src/components/Card/Post/PostCardList.jsx
@@ -58,9 +58,9 @@ const PostCardList = () => {
   };
 
   return (
-    <section
+    <article
       ref={observeRootRef}
-      className="flex flex-col justify-start gap-12 bg-white border-4 border-pink-100 rounded-[10px] pt-25 px-30 w-full h-full overflow-y-scroll"
+      className="flex flex-col justify-start gap-12 bg-white border-4 border-pink-100 rounded-[10px] pt-25 px-30 w-full h-full flex-grow overflow-y-scroll"
     >
       {postResponse?.items?.map((postInfo) => {
         return (
@@ -76,7 +76,7 @@ const PostCardList = () => {
         );
       })}
       <div className="w-full h-40" ref={observeRef}></div>
-    </section>
+    </article>
   );
 };
 

--- a/src/components/Card/Post/PostCardList.jsx
+++ b/src/components/Card/Post/PostCardList.jsx
@@ -1,5 +1,59 @@
+import { useRef } from "react";
+
+import PostCard from "./PostCard";
+
 const PostCardList = () => {
-  return;
+  const observeRef = useRef(null);
+
+  const postResponse = {
+    items: [
+      {
+        id: "9625dbd0-66e3-42fe-8084-88fa6a180a25",
+        link: "https://blog.naver.com/krystarline/223075913585",
+        title: "무엇보다 '바닐라코딩'을 선택한 이유",
+        content: "네이버 검색창에 바닐라코딩을 입력하니~~~!",
+        commentCount: 5,
+        likeCount: 10,
+        score: 50,
+        isAd: false,
+        createdAt: "2024-11-01T04:33:01.579Z",
+        updatedAt: "2024-11-01T04:33:01.579Z",
+      },
+      {
+        id: "9625dbd0-66e3-42fe-8084-88fa6a180a26",
+        link: "https://blog.naver.com/krystarline/223075913585",
+        title: "무엇보다 '바닐라코딩'을 선택한 이유2",
+        content: "네이버 검색창에 바닐라코딩을 입력하니2~~~!",
+        commentCount: 1,
+        likeCount: 9,
+        score: 80,
+        isAd: true,
+        createdAt: "2024-11-01T04:33:01.579Z",
+        updatedAt: "2024-11-01T04:33:01.579Z",
+      },
+    ],
+    nextCursorId: "234f34wfj8934j0j40gj",
+    hasNext: true,
+  };
+
+  return (
+    <section className="flex flex-col justify-start gap-12 bg-white border-4 border-pink-100 rounded-[10px] pt-25 px-30 w-full h-full overflow-y-scroll">
+      {postResponse?.items?.map((postInfo) => {
+        return (
+          <PostCard
+            key={postInfo?.id}
+            postTitle={postInfo?.title}
+            postContent={postInfo?.content}
+            likeCount={postInfo?.likeCount}
+            commentCount={postInfo?.commentCount}
+            link={postInfo?.link}
+            createdAt={postInfo?.createdAt}
+          />
+        );
+      })}
+      <div className="w-full h-40" ref={observeRef}></div>
+    </section>
+  );
 };
 
 export default PostCardList;

--- a/src/components/Card/Post/PostCardList.jsx
+++ b/src/components/Card/Post/PostCardList.jsx
@@ -1,0 +1,5 @@
+const PostCardList = () => {
+  return;
+};
+
+export default PostCardList;

--- a/src/components/Card/Post/PostCardList.jsx
+++ b/src/components/Card/Post/PostCardList.jsx
@@ -1,9 +1,30 @@
 import { useRef } from "react";
+import { useParams } from "react-router-dom";
 
+import asyncGetPosts from "../../../api/post/asyncGetPosts";
+import useInfiniteData from "../../../hooks/useInfiniteData";
 import PostCard from "./PostCard";
 
 const PostCardList = () => {
+  const { keywordId } = useParams();
   const observeRef = useRef(null);
+  const observeRootRef = useRef(null);
+
+  const infiniteDataArgument = {
+    queryKey: ["allPosts", keywordId],
+    queryFn: asyncGetPosts,
+    options: {
+      keywordId,
+      includedKeyword: "",
+      limit: 10,
+    },
+    initialPageParam: "",
+    getNextPageParam: (lastPage) => (lastPage.hasNext ? lastPage.nextCursorId : undefined),
+    ref: observeRef,
+    root: observeRootRef.current,
+  };
+
+  useInfiniteData(infiniteDataArgument);
 
   const postResponse = {
     items: [
@@ -37,7 +58,10 @@ const PostCardList = () => {
   };
 
   return (
-    <section className="flex flex-col justify-start gap-12 bg-white border-4 border-pink-100 rounded-[10px] pt-25 px-30 w-full h-full overflow-y-scroll">
+    <section
+      ref={observeRootRef}
+      className="flex flex-col justify-start gap-12 bg-white border-4 border-pink-100 rounded-[10px] pt-25 px-30 w-full h-full overflow-y-scroll"
+    >
       {postResponse?.items?.map((postInfo) => {
         return (
           <PostCard

--- a/src/components/Card/UserGroup/UserGroupCard.jsx
+++ b/src/components/Card/UserGroup/UserGroupCard.jsx
@@ -8,13 +8,13 @@ const UserGroupCard = ({ groupName, keywordList, createdAt, updatedAt }) => {
   const updatedDate = getDate(updatedAt);
 
   return (
-    <div className="flex flex-col items-start justify-center gap-3 w-full border-2 border-rose-200/80 bg-white rounded-[30px] px-20 py-10">
+    <div className="flex flex-col items-start justify-center gap-5 w-full border-2 border-rose-200/80 bg-white rounded-[30px] px-25 py-15">
       <p className="flex items-center gap-10">
-        <span className="text-purple-300 text-20">1️⃣ Group Name: </span>
+        <span className="text-purple-600 text-20">1️⃣ Group Name: </span>
         <span className="text-rose-400 text-18">{groupName}</span>
       </p>
       <p className="flex items-center gap-10">
-        <span className="text-purple-300 text-20">2️⃣ Keyword List: </span>
+        <span className="text-purple-600 text-20">2️⃣ Keyword List: </span>
         <span className="text-rose-400 text-18">
           {keywordList.map((keyword) => {
             <KeywordChip key={keyword.id} keywordName={keyword.name} />;
@@ -22,7 +22,7 @@ const UserGroupCard = ({ groupName, keywordList, createdAt, updatedAt }) => {
         </span>
       </p>
       <p className="flex items-center gap-10">
-        <span className="text-purple-300 text-20">3️⃣ Created date: </span>
+        <span className="text-purple-600 text-20">3️⃣ Created date: </span>
         <span className="text-rose-400 text-18">
           {createdDate.currentYear}년 {createdDate.currentMonth}월 {createdDate.currentDate}일{" "}
           {changeDayFormat(createdDate.currentDay)} {createdDate.currentHour}시{" "}
@@ -30,7 +30,7 @@ const UserGroupCard = ({ groupName, keywordList, createdAt, updatedAt }) => {
         </span>
       </p>
       <p className="flex items-center gap-10">
-        <span className="text-purple-300 text-20">4️⃣ Updated date: </span>
+        <span className="text-purple-600 text-20">4️⃣ Updated date: </span>
         <span className="text-rose-400 text-18">
           {updatedDate
             ? `${updatedDate.currentYear}년 ${updatedDate.currentMonth}월 ${updatedDate.currentDate}일 ${changeDayFormat(updatedDate.currentDay)} ${updatedDate.currentHour}시 ${updatedDate.currentMinute}분`

--- a/src/components/Card/UserGroup/UserGroupCard.jsx
+++ b/src/components/Card/UserGroup/UserGroupCard.jsx
@@ -1,42 +1,51 @@
+import { Link } from "react-router-dom";
+
 import changeDayFormat from "../../../utils/changeDayFormat";
 import getDate from "../../../utils/getDate";
 import KeywordChip from "../../Chip/KeywordChip";
 import PropTypes from "prop-types";
 
-const UserGroupCard = ({ groupName, keywordList, createdAt, updatedAt }) => {
+const UserGroupCard = ({ groupId, groupName, keywordList, createdAt, updatedAt }) => {
   const createdDate = getDate(createdAt);
   const updatedDate = getDate(updatedAt);
 
   return (
-    <div className="flex flex-col items-start justify-center gap-5 w-full border-2 border-rose-200/80 bg-white rounded-[30px] px-25 py-15">
-      <p className="flex items-center gap-10">
-        <span className="text-purple-600 text-20">1️⃣ Group Name: </span>
-        <span className="text-rose-400 text-18">{groupName}</span>
-      </p>
-      <p className="flex items-center gap-10">
-        <span className="text-purple-600 text-20">2️⃣ Keyword List: </span>
-        <span className="text-rose-400 text-18">
-          {keywordList.map((keyword) => {
-            <KeywordChip key={keyword.id} keywordName={keyword.name} />;
-          })}
-        </span>
-      </p>
-      <p className="flex items-center gap-10">
-        <span className="text-purple-600 text-20">3️⃣ Created date: </span>
-        <span className="text-rose-400 text-18">
-          {createdDate.currentYear}년 {createdDate.currentMonth}월 {createdDate.currentDate}일{" "}
-          {changeDayFormat(createdDate.currentDay)} {createdDate.currentHour}시{" "}
-          {createdDate.currentMinute}분
-        </span>
-      </p>
-      <p className="flex items-center gap-10">
-        <span className="text-purple-600 text-20">4️⃣ Updated date: </span>
-        <span className="text-rose-400 text-18">
-          {updatedDate
-            ? `${updatedDate.currentYear}년 ${updatedDate.currentMonth}월 ${updatedDate.currentDate}일 ${changeDayFormat(updatedDate.currentDay)} ${updatedDate.currentHour}시 ${updatedDate.currentMinute}분`
-            : "수정 내역이 없습니다"}
-        </span>
-      </p>
+    <div className="flex justify-between gap-5 w-full border-3 border-rose-200/80 bg-white rounded-[30px] pl-30 pr-20 py-15">
+      <div className="flex flex-col items-start justify-center">
+        <p className="flex items-center gap-10">
+          <span className="text-purple-600 text-19 font-bold">그룹명: </span>
+          <span className="text-rose-400 text-18">{groupName}</span>
+        </p>
+        <p className="flex items-center gap-10 w-full">
+          <span className="text-purple-600 text-19 font-bold flex-shrink-0">키워드 리스트: </span>
+          <p className="flex items-center gap-5 w-full">
+            {keywordList.map((keyword) => (
+              <KeywordChip key={keyword._id} keywordName={keyword.keyword} />
+            ))}
+          </p>
+        </p>
+        <p className="flex items-center gap-10">
+          <span className="text-purple-600 text-19 font-bold">그룹 생성일: </span>
+          <span className="text-rose-400 text-18">
+            {createdDate.currentYear}년 {createdDate.currentMonth}월 {createdDate.currentDate}일{" "}
+            {changeDayFormat(createdDate.currentDay)} {createdDate.currentHour}시{" "}
+            {createdDate.currentMinute}분
+          </span>
+        </p>
+        <p className="flex items-center gap-10">
+          <span className="text-purple-600 text-19 font-bold">그룹 수정일: </span>
+          <span className="text-rose-400 text-18">
+            {updatedDate
+              ? `${updatedDate.currentYear}년 ${updatedDate.currentMonth}월 ${updatedDate.currentDate}일 ${changeDayFormat(updatedDate.currentDay)} ${updatedDate.currentHour}시 ${updatedDate.currentMinute}분`
+              : "수정 내역이 없습니다"}
+          </span>
+        </p>
+      </div>
+      <Link to={`/dashboard/${groupId}`} className="flex items-end">
+        <p className="bottom-15 right-20 px-10 py-5 rounded-[12px] border-3 border-rose-200/80 hover:bg-rose-50 text-rose-900">
+          대시보드로 이동
+        </p>
+      </Link>
     </div>
   );
 };
@@ -44,8 +53,14 @@ const UserGroupCard = ({ groupName, keywordList, createdAt, updatedAt }) => {
 export default UserGroupCard;
 
 UserGroupCard.propTypes = {
+  groupId: PropTypes.string.isRequired,
   groupName: PropTypes.string.isRequired,
-  keywordList: PropTypes.arrayOf(PropTypes.string).isRequired,
+  keywordList: PropTypes.arrayOf(
+    PropTypes.shape({
+      _id: PropTypes.string.isRequired,
+      keyword: PropTypes.string.isRequired,
+    })
+  ).isRequired,
   createdAt: PropTypes.string.isRequired,
   updatedAt: PropTypes.string.isRequired,
 };

--- a/src/components/Card/UserGroup/UserGroupCard.jsx
+++ b/src/components/Card/UserGroup/UserGroupCard.jsx
@@ -1,8 +1,7 @@
-import { Link } from "react-router-dom";
-
 import changeDayFormat from "../../../utils/changeDayFormat";
 import getDate from "../../../utils/getDate";
 import KeywordChip from "../../Chip/KeywordChip";
+import Button from "../../UI/Button";
 import PropTypes from "prop-types";
 
 const UserGroupCard = ({ groupId, groupName, keywordList, createdAt, updatedAt }) => {
@@ -10,20 +9,20 @@ const UserGroupCard = ({ groupId, groupName, keywordList, createdAt, updatedAt }
   const updatedDate = getDate(updatedAt);
 
   return (
-    <div className="flex justify-between gap-5 w-full border-3 border-rose-200/80 bg-white rounded-[30px] pl-30 pr-20 py-15">
-      <div className="flex flex-col items-start justify-center">
+    <div className="flex justify-between w-full border-3 border-rose-200/80 bg-white rounded-[30px] pl-30 pr-20 py-10">
+      <div className="flex flex-col items-start justify-center gap-3">
         <p className="flex items-center gap-10">
           <span className="text-purple-600 text-19 font-bold">그룹명: </span>
           <span className="text-rose-400 text-18">{groupName}</span>
         </p>
-        <p className="flex items-center gap-10 w-full">
+        <div className="flex items-center gap-10 w-full">
           <span className="text-purple-600 text-19 font-bold flex-shrink-0">키워드 리스트: </span>
           <p className="flex items-center gap-5 w-full">
             {keywordList.map((keyword) => (
               <KeywordChip key={keyword._id} keywordName={keyword.keyword} />
             ))}
           </p>
-        </p>
+        </div>
         <p className="flex items-center gap-10">
           <span className="text-purple-600 text-19 font-bold">그룹 생성일: </span>
           <span className="text-rose-400 text-18">
@@ -41,11 +40,14 @@ const UserGroupCard = ({ groupId, groupName, keywordList, createdAt, updatedAt }
           </span>
         </p>
       </div>
-      <Link to={`/dashboard/${groupId}`} className="flex items-end">
-        <p className="bottom-15 right-20 px-10 py-5 rounded-[12px] border-3 border-rose-200/80 hover:bg-rose-50 text-rose-900">
+      <div className="flex items-end">
+        <Button
+          styles="px-10 py-5 rounded-[12px] border-3 border-rose-200/80 hover:bg-rose-50 text-rose-900"
+          destination={`/dashboard/${groupId}`}
+        >
           대시보드로 이동
-        </p>
-      </Link>
+        </Button>
+      </div>
     </div>
   );
 };

--- a/src/components/Card/UserGroup/UserGroupCardList.jsx
+++ b/src/components/Card/UserGroup/UserGroupCardList.jsx
@@ -8,22 +8,27 @@ const UserGroupCardList = () => {
   const hasUserUid = !!userUid;
 
   const { data: userGroupList } = useQuery({
-    queryKey: ["userGroupList", userUid],
+    queryKey: ["userGroupList"],
     queryFn: () => asyncGetUserGroup(userUid),
     enabled: hasUserUid,
   });
 
+  if (userGroupList?.groupListLength === 0) {
+    return <div className="flex flex-center w-full h-full">생성한 그룹이 없습니다. 😅</div>;
+  }
+
   return (
-    <section className="flex flex-col justify-start gap-10 bg-white border-4 border-pink-100 rounded-[10px] py-25 px-30 w-full h-full overflow-y-scroll">
-      {userGroupList?.map((groupInfo) => {
+    <section className="flex flex-col justify-start gap-15 bg-white rounded-[10px] px-30 w-full h-full overflow-y-scroll">
+      {userGroupList?.groupListResult?.map((groupInfo) => (
         <UserGroupCard
-          key={groupInfo?.id}
-          groupName={groupInfo?.groupName}
-          keywordList={groupInfo?.keywordList}
+          key={groupInfo?._id}
+          groupId={groupInfo?._id}
+          groupName={groupInfo?.name}
+          keywordList={groupInfo?.keywordIdList}
           createdAt={groupInfo?.createdAt}
           updatedAt={groupInfo?.updatedAt}
-        />;
-      })}
+        />
+      ))}
     </section>
   );
 };

--- a/src/components/Card/UserGroup/UserGroupCardList.jsx
+++ b/src/components/Card/UserGroup/UserGroupCardList.jsx
@@ -4,12 +4,12 @@ import UserGroupCard from "./UserGroupCard";
 import { useQuery } from "@tanstack/react-query";
 
 const UserGroupCardList = () => {
-  const userId = useBoundStore((state) => state.userInfo.id);
-  const hasUserId = !!userId;
+  const userUid = useBoundStore((state) => state.userInfo.uid);
+  const hasUserId = !!userUid;
 
   const { data: userGroupList } = useQuery({
-    queryKey: ["userGroupList", userId],
-    queryFn: () => asyncGetUserGroup(userId),
+    queryKey: ["userGroupList", userUid],
+    queryFn: () => asyncGetUserGroup(userUid),
     enabled: hasUserId,
   });
 

--- a/src/components/Card/UserGroup/UserGroupCardList.jsx
+++ b/src/components/Card/UserGroup/UserGroupCardList.jsx
@@ -5,12 +5,12 @@ import { useQuery } from "@tanstack/react-query";
 
 const UserGroupCardList = () => {
   const userUid = useBoundStore((state) => state.userInfo.uid);
-  const hasUserId = !!userUid;
+  const hasUserUid = !!userUid;
 
   const { data: userGroupList } = useQuery({
     queryKey: ["userGroupList", userUid],
     queryFn: () => asyncGetUserGroup(userUid),
-    enabled: hasUserId,
+    enabled: hasUserUid,
   });
 
   return (

--- a/src/components/Card/UserGroup/UserGroupCardList.jsx
+++ b/src/components/Card/UserGroup/UserGroupCardList.jsx
@@ -14,7 +14,7 @@ const UserGroupCardList = () => {
   });
 
   return (
-    <section className="flex flex-col justify-start gap-10 bg-white border-4 border-pink-200 rounded-[10px] py-40 px-40 w-full h-full overflow-y-scroll">
+    <section className="flex flex-col justify-start gap-10 bg-white border-4 border-pink-100 rounded-[10px] py-25 px-30 w-full h-full overflow-y-scroll">
       {userGroupList?.map((groupInfo) => {
         <UserGroupCard
           key={groupInfo?.id}

--- a/src/components/Card/UserGroup/UserGroupCardList.jsx
+++ b/src/components/Card/UserGroup/UserGroupCardList.jsx
@@ -4,6 +4,7 @@ import UserGroupCard from "./UserGroupCard";
 import { useQuery } from "@tanstack/react-query";
 
 const UserGroupCardList = () => {
+  const setUserGroupList = useBoundStore((state) => state.setUserGroupList);
   const userUid = useBoundStore((state) => state.userInfo.uid);
   const hasUserUid = !!userUid;
 
@@ -15,6 +16,10 @@ const UserGroupCardList = () => {
 
   if (userGroupList?.groupListLength === 0) {
     return <div className="flex flex-center w-full h-full">생성한 그룹이 없습니다. 😅</div>;
+  }
+
+  if (userGroupList?.groupListResult) {
+    setUserGroupList(userGroupList?.groupListResult);
   }
 
   return (

--- a/src/components/Card/UserGroup/UserGroupCardList.jsx
+++ b/src/components/Card/UserGroup/UserGroupCardList.jsx
@@ -5,12 +5,12 @@ import { useQuery } from "@tanstack/react-query";
 
 const UserGroupCardList = () => {
   const userId = useBoundStore((state) => state.userInfo.id);
-  // const hasUserId = !!userId;
+  const hasUserId = !!userId;
 
   const { data: userGroupList } = useQuery({
     queryKey: ["userGroupList", userId],
     queryFn: () => asyncGetUserGroup(userId),
-    // enabled: hasUserId,
+    enabled: hasUserId,
   });
 
   return (

--- a/src/components/Chip/KeywordChip.jsx
+++ b/src/components/Chip/KeywordChip.jsx
@@ -2,7 +2,9 @@ import PropTypes from "prop-types";
 
 const KeywordChip = ({ keywordName }) => {
   return (
-    <span className="flex-center text-14 px-3 py-2 bg-orange-200 rounded-[3px]">{keywordName}</span>
+    <span className="flex-center text-14 px-5 py-2 bg-orange-100 text-rose-800 rounded-[3px]">
+      {keywordName}
+    </span>
   );
 };
 

--- a/src/components/DropDown/SelectGroupDropDown.jsx
+++ b/src/components/DropDown/SelectGroupDropDown.jsx
@@ -28,19 +28,19 @@ const SelectGroupDropDown = memo(function SelectGroupDropDown({
       onClick={handleDropDownClick}
     >
       <span className="flex-grow w-full" ref={dropDownBoxTextRef}>
-        {selectedGroup}
+        {selectedGroup?.name}
       </span>
       {isDropDownOpen ? (
-        <>
-          <TriangleUpIcon className="size-20 fill-purple-300" />
-          <SelectGroupOptionList
-            groupList={groupList}
-            selectedGroup={selectedGroup}
-            setSelectedGroup={setSelectedGroup}
-          />
-        </>
+        <TriangleUpIcon className="size-20 fill-purple-300" />
       ) : (
         <TriangleDownIcon className="size-20 fill-purple-300" />
+      )}
+      {isDropDownOpen && (
+        <SelectGroupOptionList
+          groupList={groupList}
+          selectedGroup={selectedGroup}
+          setSelectedGroup={setSelectedGroup}
+        />
       )}
     </div>
   );
@@ -49,10 +49,13 @@ const SelectGroupDropDown = memo(function SelectGroupDropDown({
 export default SelectGroupDropDown;
 
 SelectGroupDropDown.propTypes = {
-  selectedGroup: PropTypes.string.isRequired,
+  selectedGroup: PropTypes.shape({
+    id: PropTypes.string,
+    name: PropTypes.string,
+  }).isRequired,
   groupList: PropTypes.arrayOf(
     PropTypes.shape({
-      id: PropTypes.number,
+      id: PropTypes.string,
       name: PropTypes.string,
     })
   ).isRequired,

--- a/src/components/DropDown/SelectGroupOptionList.jsx
+++ b/src/components/DropDown/SelectGroupOptionList.jsx
@@ -1,8 +1,8 @@
 import PropTypes from "prop-types";
 
 const SelectGroupOptionList = ({ groupList, selectedGroup, setSelectedGroup }) => {
-  const handleListClick = (groupName) => {
-    setSelectedGroup(groupName);
+  const handleListClick = (groupId, groupName) => {
+    setSelectedGroup((prev) => ({ ...prev, id: groupId, name: groupName }));
   };
 
   return (
@@ -10,14 +10,15 @@ const SelectGroupOptionList = ({ groupList, selectedGroup, setSelectedGroup }) =
       className="absolute flex flex-col items-center top-50 right-0 w-full max-h-120 overflow-y-scroll bg-white z-modalDropDown border-purple-300 border-2 rounded-[10px] text-purple-900 font-semibold shadow-xl"
       id="selectGroupDropDown"
     >
-      {groupList.map((group, index) => {
+      {groupList?.map((group, index) => {
+        const groupId = group.id;
         const groupName = group.name;
 
         return (
           <div
-            key={group.id}
-            className={`flex-center flex-shrink-0 w-full h-30 border-purple-300 hover:bg-neutral-100 ${selectedGroup === groupName && "bg-violet-100/80"} ${index !== groupList.length - 1 && "border-b-1"} ${groupName === "새로 만들기" && "text-rose-400"}`}
-            onClick={() => handleListClick(groupName)}
+            key={groupId}
+            className={`flex-center flex-shrink-0 w-full h-30 border-purple-300 hover:bg-neutral-100 ${selectedGroup.id === groupId && "bg-violet-100/80"} ${index !== groupList.length - 1 && "border-b-1"}`}
+            onClick={() => handleListClick(groupId, groupName)}
           >
             {groupName}
           </div>
@@ -32,10 +33,13 @@ export default SelectGroupOptionList;
 SelectGroupOptionList.propTypes = {
   groupList: PropTypes.arrayOf(
     PropTypes.shape({
-      id: PropTypes.number,
+      id: PropTypes.string,
       name: PropTypes.string,
     })
   ).isRequired,
-  selectedGroup: PropTypes.string.isRequired,
+  selectedGroup: PropTypes.shape({
+    id: PropTypes.string,
+    name: PropTypes.string,
+  }).isRequired,
   setSelectedGroup: PropTypes.func.isRequired,
 };

--- a/src/components/Header/DashboardHeader.jsx
+++ b/src/components/Header/DashboardHeader.jsx
@@ -1,0 +1,9 @@
+const DashboardHeader = () => {
+  return (
+    <div className="flex justify-between items-center w-full h-100 bg-white border-1 shadow-sm px-20 py-10">
+      대시보드 헤더
+    </div>
+  );
+};
+
+export default DashboardHeader;

--- a/src/components/Icon/ProfileIcon.jsx
+++ b/src/components/Icon/ProfileIcon.jsx
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 const ProfileIcon = ({ size, photoURL }) => {
   return (
     <div
-      className={`rounded-full overflow-hidden border-3 border-pink-200 hover:border-pink-300 ${size}`}
+      className={`flex-shrink-0 rounded-full overflow-hidden border-3 border-pink-200 hover:border-pink-300 ${size}`}
     >
       <img src={photoURL} alt="프로필 사진" className="h-full w-full object-cover" />
     </div>

--- a/src/components/Modal/CreateKeywordModal.jsx
+++ b/src/components/Modal/CreateKeywordModal.jsx
@@ -137,7 +137,7 @@ const CreateKeywordModal = () => {
             onSubmit={handleKeywordSubmit}
           >
             {isPending ? (
-              <Loading width={100} height={100} text={"블로그를 가져오는 중입니다"} />
+              <Loading width={100} height={100} text={"블로그를 가져오는 중입니다...💜"} />
             ) : (
               <>
                 <div className="w-full flex items-start mb-18 gap-20">

--- a/src/components/Modal/CreateKeywordModal.jsx
+++ b/src/components/Modal/CreateKeywordModal.jsx
@@ -48,7 +48,7 @@ const CreateKeywordModal = () => {
     },
   ]);
 
-  const userId = useBoundStore((state) => state.userInfo.id);
+  const userUid = useBoundStore((state) => state.userInfo.uid);
   const addModal = useBoundStore((state) => state.addModal);
   const closeModal = useBoundStore((state) => state.closeModal);
   const queryClient = useQueryClient();
@@ -98,11 +98,16 @@ const CreateKeywordModal = () => {
       groupId: "",
       groupName: selectedGroup,
       keyword: keywordValue,
-      ownerId: userId,
+      ownerUid: userUid,
     };
 
     createKeywordMutation.mutate(keywordInfo, {
       onSuccess: (data) => {
+        if (data?.message?.includes("Error occured")) {
+          addModal(MODAL_TYPE.ERROR);
+          return;
+        }
+
         closeModal(MODAL_TYPE.CREATE_KEYWORD);
         addModal(MODAL_TYPE.CREATE_KEYWORD_SUCCESS);
         queryClient.invalidateQueries({ queryKey: ["userGroupList", data.ownerId] });

--- a/src/components/Sidebar/DashboardSidebar.jsx
+++ b/src/components/Sidebar/DashboardSidebar.jsx
@@ -1,0 +1,9 @@
+const DashboardSidebar = () => {
+  return (
+    <div className="flex-col-center w-250 h-full flex-shrink-0 bg-white border-l-1 border-r-1 shadow-sm">
+      대시보드 사이드바
+    </div>
+  );
+};
+
+export default DashboardSidebar;

--- a/src/components/Sidebar/MyPageSidebar.jsx
+++ b/src/components/Sidebar/MyPageSidebar.jsx
@@ -16,17 +16,17 @@ const MyPageSidebar = () => {
   };
 
   return (
-    <aside className="flex flex-col gap-20">
-      <div className="flex flex-col items-center gap-25 w-250 h-350 py-30 px-30 rounded-[30px] bg-white border-4 border-pink-200">
-        <ProfileIcon size="w-165 h-165" photoURL={userInfo.photoURL} />
-        <div className="w-full border-t-3 border-pink-200"></div>
-        <div className="flex flex-col items-center w-full gap-10 text-pink-900/90">
+    <aside className="flex gap-20 w-full px-30 lg:px-0 lg:w-fit lg:flex-col">
+      <div className="flex lg:flex-col items-center gap-25 w-full lg:w-250 h-100 lg:h-350 px-40 lg:px-30 py-10 lg:py-30 rounded-[30px] bg-white border-4 border-pink-200 flex-grow lg:flex-grow-0">
+        <ProfileIcon size="w-70 h-70 lg:w-165 lg:h-165" photoURL={userInfo.photoURL} />
+        <div className="hidden lg:block w-full border-t-3 border-pink-200"></div>
+        <div className="flex lg:flex-col justify-center  lg:justify-start items-center w-full gap-30 lg:gap-10 text-pink-900/90">
           <p className="text-18 font-semibold">{userInfo.displayName}</p>
-          <p>{userInfo.email}</p>
+          <p className="text-18 lg:text-16">{userInfo.email}</p>
         </div>
       </div>
       <Button
-        styles="w-full px-20 py-12 text-21 text-pink-900 font-bold bg-rose-100 border-2 border-rose-200/80 rounded-[20px] hover:bg-rose-200/80"
+        styles="w-300 lg:w-full px-20 py-12 text-21 text-pink-900 font-bold bg-rose-100 border-2 border-rose-200/80 rounded-[20px] hover:bg-rose-200/80"
         onClick={handleCreateKeywordButton}
       >
         키워드 만들기

--- a/src/components/Sidebar/MyPageSidebar.jsx
+++ b/src/components/Sidebar/MyPageSidebar.jsx
@@ -17,16 +17,16 @@ const MyPageSidebar = () => {
 
   return (
     <aside className="flex gap-20 w-full px-30 lg:px-0 lg:w-fit lg:flex-col">
-      <div className="flex lg:flex-col items-center gap-25 w-full lg:w-250 h-100 lg:h-350 px-40 lg:px-30 py-10 lg:py-30 rounded-[30px] bg-white border-4 border-pink-200 flex-grow lg:flex-grow-0">
+      <div className="flex lg:flex-col items-center gap-25 w-full lg:w-250 h-100 lg:h-350 px-30 lg:px-30 py-10 lg:py-30 rounded-[30px] bg-white border-4 border-pink-200 flex-grow lg:flex-grow-0">
         <ProfileIcon size="w-70 h-70 lg:w-165 lg:h-165" photoURL={userInfo.photoURL} />
         <div className="hidden lg:block w-full border-t-3 border-pink-200"></div>
-        <div className="flex lg:flex-col justify-center  lg:justify-start items-center w-full gap-30 lg:gap-10 text-pink-900/90">
+        <div className="flex flex-col md:flex-row lg:flex-col justify-center lg:justify-start items-center w-full gap-10 md:gap-30 lg:gap-10 text-pink-900/90">
           <p className="text-18 font-semibold">{userInfo.displayName}</p>
           <p className="text-18 lg:text-16">{userInfo.email}</p>
         </div>
       </div>
       <Button
-        styles="w-300 lg:w-full px-20 py-12 text-21 text-pink-900 font-bold bg-rose-100 border-2 border-rose-200/80 rounded-[20px] hover:bg-rose-200/80"
+        styles="w-300 lg:w-full px-10 lg:px-20 lg:py-22 text-21 text-pink-900 font-bold bg-rose-100 border-2 border-rose-200/80 rounded-[20px] hover:bg-rose-200/80"
         onClick={handleCreateKeywordButton}
       >
         키워드 만들기

--- a/src/components/UI/Error.jsx
+++ b/src/components/UI/Error.jsx
@@ -1,0 +1,15 @@
+import PropTypes from "prop-types";
+
+const Error = ({ errorMessage }) => {
+  return (
+    <main className="flex-center w-full h-full">
+      <h1 className="text-18 text-red-400">{errorMessage} 😅</h1>
+    </main>
+  );
+};
+
+export default Error;
+
+Error.propTypes = {
+  errorMessage: PropTypes.string.isRequired,
+};

--- a/src/components/UI/Loading.jsx
+++ b/src/components/UI/Loading.jsx
@@ -2,9 +2,9 @@ import PropTypes from "prop-types";
 
 const Loading = ({ width, height, text }) => {
   return (
-    <div className="flex-col-center">
+    <div className="flex-col-center flex-shrink-0">
       <img src="/assets/spinnerGif.gif" alt="로딩 이미지" width={width} height={height} />
-      {text}...💜
+      {text}
     </div>
   );
 };

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -7,6 +7,7 @@ export const MODAL_TYPE = Object.freeze({
 });
 
 export const ERROR_MESSAGE = Object.freeze({
+  MUST_GROUP_SELECT: "그룹을 선택해주세요.",
   NEW_GROUP_EMPTY_INPUT_VALUE: "그룹명을 입력해주세요.",
   KEYWORD_EMPTY_INPUT_VALUE: "키워드를 입력해주세요.",
   CREATE_KEYWORD_ERROR: "새로운 키워드 생성에 실패하였습니다.",

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -11,6 +11,7 @@ export const ERROR_MESSAGE = Object.freeze({
   KEYWORD_EMPTY_INPUT_VALUE: "키워드를 입력해주세요.",
   CREATE_KEYWORD_ERROR: "새로운 키워드 생성에 실패하였습니다.",
   SIGN_IN_ERROR: "로그인에 실패하였습니다.",
+  FETCH_POSTS: "블로그 정보를 불러오지 못했습니다.",
 });
 
 export const POST_LISTS = Object.freeze({

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -10,6 +10,7 @@ export const ERROR_MESSAGE = Object.freeze({
   NEW_GROUP_EMPTY_INPUT_VALUE: "그룹명을 입력해주세요.",
   KEYWORD_EMPTY_INPUT_VALUE: "키워드를 입력해주세요.",
   CREATE_KEYWORD_ERROR: "새로운 키워드 생성에 실패하였습니다.",
+  SIGN_IN_ERROR: "로그인에 실패하였습니다.",
 });
 
 export const POST_LISTS = Object.freeze({

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -17,6 +17,6 @@ export const ERROR_MESSAGE = Object.freeze({
 
 export const POST_LISTS = Object.freeze({
   DEFAULT_INCLUDED_KEYWORD: "",
-  LIMIT: 10,
-  CURSOR_ID: "",
+  DEFAULT_LIMIT: 10,
+  DEFAULT_CURSOR_ID: "",
 });

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -1,3 +1,5 @@
+export const BASE_URL = "http://localhost:3000";
+
 export const MODAL_TYPE = Object.freeze({
   CREATE_KEYWORD: "createKeyword",
   CREATE_KEYWORD_SUCCESS: "createKeywordSuccess",
@@ -10,4 +12,8 @@ export const ERROR_MESSAGE = Object.freeze({
   CREATE_KEYWORD_ERROR: "새로운 키워드 생성에 실패하였습니다.",
 });
 
-export const BASE_URL = "http://localhost:3000";
+export const POST_LISTS = Object.freeze({
+  DEFAULT_INCLUDED_KEYWORD: "",
+  LIMIT: 10,
+  CURSOR_ID: "",
+});

--- a/src/hooks/useInfiniteData.js
+++ b/src/hooks/useInfiniteData.js
@@ -1,0 +1,36 @@
+import useObserver from "./useObserver";
+import { useInfiniteQuery } from "@tanstack/react-query";
+
+const useInfiniteData = ({
+  queryKey,
+  queryFn,
+  options,
+  initialPageParam,
+  getNextPageParam,
+  ref,
+  root,
+}) => {
+  const { data, status, fetchNextPage, isPending, isError, ...rest } = useInfiniteQuery({
+    queryKey,
+    queryFn: ({ pageParam }) => queryFn(pageParam, options),
+    initialPageParam,
+    getNextPageParam,
+    staleTime: 10 * 1000,
+  });
+
+  const onIntersect = (entries) => {
+    if (isPending) return;
+
+    entries.forEach((element) => {
+      if (element.isIntersecting) {
+        fetchNextPage();
+      }
+    });
+  };
+
+  useObserver({ ref, root: root, threshold: 0.6, onIntersect });
+
+  return { data, status, fetchNextPage, isPending, isError, ...rest };
+};
+
+export default useInfiniteData;

--- a/src/hooks/useInfiniteData.js
+++ b/src/hooks/useInfiniteData.js
@@ -20,15 +20,16 @@ const useInfiniteData = ({
 
   const onIntersect = (entries) => {
     if (isPending) return;
+    if (!data?.pages[data?.pages.length - 1].hasNext) return;
 
-    entries.forEach((element) => {
-      if (element.isIntersecting) {
+    entries.forEach((entry) => {
+      if (entry.isIntersecting) {
         fetchNextPage();
       }
     });
   };
 
-  useObserver({ ref, root: root, threshold: 0.6, onIntersect });
+  useObserver({ target: ref, root, threshold: 0.5, onIntersect });
 
   return { data, status, fetchNextPage, isPending, isError, ...rest };
 };

--- a/src/hooks/useNoSignInRedirect.js
+++ b/src/hooks/useNoSignInRedirect.js
@@ -12,7 +12,7 @@ const useNoSignInRedirect = () => {
   const user = auth.currentUser;
 
   useEffect(() => {
-    if (!isSignIn || !user) {
+    if (!user || !isSignIn) {
       navigate("/");
     }
   }, [isSignIn, navigate, user]);

--- a/src/hooks/useObserver.js
+++ b/src/hooks/useObserver.js
@@ -1,0 +1,36 @@
+import { useEffect } from "react";
+
+const useObserver = ({
+  target,
+  root = null,
+  rootMargin = "0px 0px 0px 0px",
+  threshold = 1.0,
+  onIntersect,
+}) => {
+  useEffect(() => {
+    let observer;
+
+    if (target && target.current) {
+      observer = new IntersectionObserver(
+        (entries, observer) => {
+          onIntersect(entries, observer);
+        },
+        {
+          root,
+          rootMargin,
+          threshold,
+        }
+      );
+
+      observer.observe(target.current);
+    }
+
+    return () => {
+      if (observer) {
+        observer.disconnect();
+      }
+    };
+  }, [target, root, rootMargin, threshold, onIntersect]);
+};
+
+export default useObserver;

--- a/src/pages/GroupPage.jsx
+++ b/src/pages/GroupPage.jsx
@@ -1,5 +1,15 @@
+import DashboardHeader from "../components/Header/DashboardHeader";
+import DashboardSidebar from "../components/Sidebar/DashboardSidebar";
+
 const GroupPage = () => {
-  return;
+  return (
+    <main className="flex justify-start items-start gap-50 mx-auto pt-67 h-screen w-full max-w-1440 pr-40">
+      <DashboardSidebar />
+      <section className="w-full h-full flex flex-col justify-start">
+        <DashboardHeader />
+      </section>
+    </main>
+  );
 };
 
 export default GroupPage;

--- a/src/pages/GroupPage.jsx
+++ b/src/pages/GroupPage.jsx
@@ -3,7 +3,7 @@ import DashboardSidebar from "../components/Sidebar/DashboardSidebar";
 
 const GroupPage = () => {
   return (
-    <main className="flex justify-start items-start gap-50 mx-auto pt-67 h-screen w-full max-w-1440 pr-40">
+    <main className="flex justify-start items-start mx-auto pt-67 h-screen w-full max-w-1440">
       <DashboardSidebar />
       <section className="w-full h-full flex flex-col justify-start">
         <DashboardHeader />

--- a/src/pages/KeywordPage.jsx
+++ b/src/pages/KeywordPage.jsx
@@ -1,11 +1,17 @@
 import PostCardList from "../components/Card/Post/PostCardList";
+import DashboardHeader from "../components/Header/DashboardHeader";
+import DashboardSidebar from "../components/Sidebar/DashboardSidebar";
 
 const KeywordPage = () => {
   // useNoSignInRedirect();
 
   return (
-    <main className="flex flex-col justify-start mx-auto pl-250 pt-80 h-screen w-full max-w-1200 pr-40 pb-30">
-      <PostCardList />
+    <main className="flex justify-start items-start mx-auto pt-67 h-screen w-full max-w-1440">
+      <DashboardSidebar />
+      <section className="w-full h-full flex flex-col justify-start">
+        <DashboardHeader />
+        <PostCardList />
+      </section>
     </main>
   );
 };

--- a/src/pages/KeywordPage.jsx
+++ b/src/pages/KeywordPage.jsx
@@ -1,11 +1,10 @@
 import PostCardList from "../components/Card/Post/PostCardList";
-import useNoSignInRedirect from "../hooks/useNoSignInRedirect";
 
 const KeywordPage = () => {
-  useNoSignInRedirect();
+  // useNoSignInRedirect();
 
   return (
-    <main className="flex items-start gap-50 mx-auto mt-80 w-full max-w-1200 px-40 py-30">
+    <main className="flex flex-col justify-start mx-auto pl-250 pt-80 h-screen w-full max-w-1200 pr-40 pb-30">
       <PostCardList />
     </main>
   );

--- a/src/pages/KeywordPage.jsx
+++ b/src/pages/KeywordPage.jsx
@@ -1,5 +1,14 @@
+import PostCardList from "../components/Card/Post/PostCardList";
+import useNoSignInRedirect from "../hooks/useNoSignInRedirect";
+
 const KeywordPage = () => {
-  return;
+  useNoSignInRedirect();
+
+  return (
+    <main className="flex items-start gap-50 mx-auto mt-80 w-full max-w-1200 px-40 py-30">
+      <PostCardList />
+    </main>
+  );
 };
 
 export default KeywordPage;

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -6,7 +6,7 @@ const MyPage = () => {
   useNoSignInRedirect();
 
   return (
-    <main className="flex items-start gap-20 mx-auto pt-100 w-full h-screen max-w-1200 px-40 pb-10">
+    <main className="flex flex-col items-start gap-20 mx-auto pt-100 w-full h-screen max-w-1200 px-40 pb-10 lg:flex-row">
       <MyPageSidebar />
       <UserGroupCardList />
     </main>

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -6,7 +6,7 @@ const MyPage = () => {
   useNoSignInRedirect();
 
   return (
-    <main className="flex items-start gap-40 mx-auto pt-100 w-full h-screen max-w-1200 px-40 py-30">
+    <main className="flex items-start gap-20 mx-auto pt-100 w-full h-screen max-w-1200 px-40 pb-10">
       <MyPageSidebar />
       <UserGroupCardList />
     </main>

--- a/src/store/client/authSlice.js
+++ b/src/store/client/authSlice.js
@@ -4,32 +4,28 @@ import { GoogleAuthProvider, getAuth, signInWithPopup, signOut } from "firebase/
 const createAuthSlice = (set) => ({
   isSignIn: false,
   userInfo: {
-    id: "",
+    uid: "",
     email: "",
     displayName: "",
     photoURL: "",
   },
   error: {
-    signInError: "",
+    googleSignInError: "",
+    serverSignInError: "",
   },
+  setIsSignIn: (isSignIn) => set((state) => ({ ...state, isSignIn })),
+  setUserInfo: (userInfo) => set((state) => ({ ...state, userInfo })),
+  setServerSignInError: (errorMessage) =>
+    set((state) => ({ ...state, error: { serverSignInError: errorMessage } })),
   asyncSignIn: async () => {
     try {
       const provider = new GoogleAuthProvider();
       const signInResponse = await signInWithPopup(auth, provider);
       const { uid, email, displayName, photoURL } = signInResponse.user;
 
-      set((state) => ({
-        ...state,
-        isSignIn: true,
-        userInfo: {
-          id: uid,
-          email,
-          displayName,
-          photoURL,
-        },
-      }));
+      return { uid, email, displayName, photoURL };
     } catch ({ message }) {
-      set((state) => ({ ...state, error: { signInError: message } }));
+      set((state) => ({ ...state, error: { googleSignInError: message } }));
     }
   },
   signOut: () => {
@@ -38,12 +34,10 @@ const createAuthSlice = (set) => ({
       ...state,
       isSignIn: false,
       userInfo: {
-        id: "",
+        uid: "",
         email: "",
         displayName: "",
         photoURL: "",
-        joinedAt: null,
-        lastSignInAt: null,
       },
     }));
     signOut(auth);

--- a/src/store/client/userDataSlice.js
+++ b/src/store/client/userDataSlice.js
@@ -5,8 +5,7 @@ const createUserDataSlice = (set) => ({
     keywordCrawlingError: "",
   },
   setIsKeywordCrawling: (isPending) => set((state) => ({ ...state, isKeywordCrawling: isPending })),
-  setUserGroupList: (groupList) =>
-    set((state) => ({ ...state, userGroupList: [...state.userGroupList, ...groupList] })),
+  setUserGroupList: (groupList) => set((state) => ({ ...state, userGroupList: [...groupList] })),
 });
 
 export default createUserDataSlice;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -11,14 +11,14 @@ const createPxEntries = (size) => {
 
 const PX_ENTRIES_10 = createPxEntries(10);
 const PX_ENTRIES_200 = createPxEntries(200);
-const PX_ENTRIES_1200 = createPxEntries(1200);
+const PX_ENTRIES_1440 = createPxEntries(1440);
 
 export default {
   content: ["./index.html", "./src/**/*.{js,jsx}"],
   theme: {
     borderWidth: PX_ENTRIES_10,
     fontSize: PX_ENTRIES_200,
-    spacing: PX_ENTRIES_1200,
+    spacing: PX_ENTRIES_1440,
     zIndex: {
       header: "30",
       modal: "40",


### PR DESCRIPTION
## 이슈

- close #11 #8 #2 

## 구현 화면

### 마이페이지 반응형 (화면이 줄어들 경우, 사용자 그룹 리스트가 깨지는 현상 보정)

![image](https://github.com/user-attachments/assets/ade170cc-9c34-45d0-bc34-d8592fdcefbd)

### 마이페이지

![image](https://github.com/user-attachments/assets/aa812bbe-0cb5-4f1b-8082-724a73e190d4)

### 키워드 대시보드 게시물 무한스크롤

![무한스크롤](https://github.com/user-attachments/assets/a246ca07-f213-45c7-96a9-1ac0e972e3c3)

## 상세 설명

- userId => userUid 변수명 수정하였습니다.
- 무한 스크롤 구현을 위한 `asyncGetPosts`, `useObserver` 및 `useInfiniteData` 구현하였습니다.
  - `useObserver` 은 여러 옵션을 넣어서 쓸 수 있도록 구현하였습니다. root, rootMargin, threshold(1.0이면 대상 전체가 보이는 것)는 기본값을 부여하였습니다. 
  - `useInfiniteData`는 `useInfiniteQuery`의 옵션으로 쓰는 `queryKey`, `queryFn`, `options`, `initialPageParam`, `getNextPageParam` 을 받고, `useObserver`에서 쓰는 `ref`와 `root`를 받습니다. `root`를 따로 설정하지 않으면 document's viewport를 `root`로 둡니다.
  - [MDN 공식문서: IntersectionObserver()](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/IntersectionObserver)
- 사용자 정보를 서버에 보내기 위해 `SignInButton`에 로직을 추가하였습니다. 추가로, authSlice의 `asyncSignIn()`의 로직에서 전역 상태를 set하는 로직을 제거하였습니다.
- 여러 가지 에러 상황에 대한 fallbackUI를 구현하였습니다.
  - `Error` UI 및 `Error Modal`
- 키워드 등록 모달에서 새로운 그룹을 추가하면 더이상 그룹을 추가하지 못하도록 엣지케이스 방지 하였습니다. (로컬에서 아무리 그룹을 추가해도 서버에 반영되지 않기 때문에, 유저에게 혼란을 줍니다.)

## 참고사항

- `GroupPage`와 `KeywordPage`의 레이아웃을 짰습니다. 참고 부탁드립니다.
- `KeywordPage`에 주석이 있는데, 로그인된 상황이 아니면 홈으로 리다이렉트 시키는 훅입니다. dashboard 페이지의 테스트를 위해서 해놓았는데, merge 시 지우도록 하겠습니다.

## PR 체크 사항

- [ ] conflict를 모두 해결하였습니다.
- [ ] 가장 최신 dev 브랜치를 pull 하였습니다.
- [ ] 코드 컨벤션을 모두 확인하였습니다.
- [ ] `console.log`나 주석 여부를 확인하였습니다.
- [ ] 브랜치명을 확인하였습니다.
- [ ] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!

## 리뷰 반영사항

-

## PR 리뷰 마감시간

- 2024년 11월 10일 까지
