### PR TITLE
Feat: 키워드 대시보드 내 주간 댓글 수, 좋아요 수 차트 UI 구현

### DIFF
--- a/src/api/keyword/asyncGetPostCommentList.js
+++ b/src/api/keyword/asyncGetPostCommentList.js
@@ -1,0 +1,15 @@
+import fetchHandler from "..";
+import { BASE_URL } from "../../config/constants";
+
+const asyncGetPostLikeList = async (keywordId, cursorId) => {
+  const fetchInfo = {
+    url: `${BASE_URL}/posts/keywords/${keywordId}/postComment`,
+    params: `?cursorId=${cursorId}`,
+  };
+
+  const response = await fetchHandler(fetchInfo);
+
+  return response;
+};
+
+export default asyncGetPostLikeList;

--- a/src/api/keyword/asyncGetPostLikeList.js
+++ b/src/api/keyword/asyncGetPostLikeList.js
@@ -1,0 +1,15 @@
+import fetchHandler from "..";
+import { BASE_URL } from "../../config/constants";
+
+const asyncGetPostLikeList = async (keywordId, cursorId) => {
+  const fetchInfo = {
+    url: `${BASE_URL}/posts/keywords/${keywordId}/postLike`,
+    params: `?cursorId=${cursorId}`,
+  };
+
+  const response = await fetchHandler(fetchInfo);
+
+  return response;
+};
+
+export default asyncGetPostLikeList;

--- a/src/components/Card/Chart/PeriodPostCommentCard.jsx
+++ b/src/components/Card/Chart/PeriodPostCommentCard.jsx
@@ -1,0 +1,55 @@
+import { useState } from "react";
+
+import asyncGetPostCommentList from "../../../api/keyword/asyncGetPostCommentList";
+import { getCursorDate } from "../../../utils/date";
+import BarChart from "../../Chart/BarChart";
+import PeriodPagination from "../../Pagination/PeriodPagination";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import PropTypes from "prop-types";
+
+const PeriodPostCommentCard = ({ keywordId }) => {
+  const [cursorId, setCursorId] = useState(() => getCursorDate());
+
+  const {
+    data: chartData,
+    isPlaceholderData,
+    isError,
+  } = useQuery({
+    queryKey: ["postComment", keywordId, cursorId],
+    queryFn: () => asyncGetPostCommentList(keywordId, cursorId),
+    select: (data) => (data = { ...data, items: data.postCommentList }),
+    placeholderData: keepPreviousData,
+  });
+
+  if (chartData === undefined) {
+    return null;
+  }
+
+  if (isError || chartData?.message?.includes("Error occured")) {
+    return (
+      <div className="w-1/2 h-full p-10 border-2 rounded-md flex justify-center items-center">
+        주간 댓글 수 차트를 불러오는 데 실패했습니다.
+      </div>
+    );
+  }
+
+  return (
+    <article className="flex flex-col gap-6 w-1/2 h-full p-10 border-2 rounded-md">
+      <span className="flex-shrink-0 bg-green-100/20 px-10 py-5 rounded-[2px]">주간 댓글 수</span>
+      <div className="flex-col-center">
+        <BarChart chartData={chartData} />
+        <PeriodPagination
+          chartData={chartData}
+          setCursorId={setCursorId}
+          isPlaceholderData={isPlaceholderData}
+        />
+      </div>
+    </article>
+  );
+};
+
+export default PeriodPostCommentCard;
+
+PeriodPostCommentCard.propTypes = {
+  keywordId: PropTypes.string.isRequired,
+};

--- a/src/components/Card/Chart/PeriodPostCommentCard.jsx
+++ b/src/components/Card/Chart/PeriodPostCommentCard.jsx
@@ -17,7 +17,7 @@ const PeriodPostCommentCard = ({ keywordId }) => {
   } = useQuery({
     queryKey: ["postComment", keywordId, cursorId],
     queryFn: () => asyncGetPostCommentList(keywordId, cursorId),
-    select: (data) => (data = { ...data, items: data.postCommentList }),
+    select: (data) => ({ ...data, items: data.postCommentList }),
     placeholderData: keepPreviousData,
   });
 

--- a/src/components/Card/Chart/PeriodPostCountCard.jsx
+++ b/src/components/Card/Chart/PeriodPostCountCard.jsx
@@ -17,6 +17,7 @@ const PeriodPostCountCard = ({ keywordId }) => {
   } = useQuery({
     queryKey: ["postCount", keywordId, cursorId],
     queryFn: () => asyncGetPostCountList(keywordId, cursorId),
+    select: (data) => ({ ...data, items: data.postCountList }),
     placeholderData: keepPreviousData,
   });
 

--- a/src/components/Card/Chart/PeriodPostLikeCard.jsx
+++ b/src/components/Card/Chart/PeriodPostLikeCard.jsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 
 import asyncGetPostLikeList from "../../../api/keyword/asyncGetPostLikeList";
 import { getCursorDate } from "../../../utils/date";
-import BarChart from "../../Chart/BarChart";
+import LineChart from "../../Chart/LineChart";
 import PeriodPagination from "../../Pagination/PeriodPagination";
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import PropTypes from "prop-types";
@@ -15,9 +15,9 @@ const PeriodPostLikeCard = ({ keywordId }) => {
     isPlaceholderData,
     isError,
   } = useQuery({
-    queryKey: ["postCount", keywordId, cursorId],
+    queryKey: ["postLike", keywordId, cursorId],
     queryFn: () => asyncGetPostLikeList(keywordId, cursorId),
-    select: (data) => (data = { ...data, items: data.postLikeList }),
+    select: (data) => ({ ...data, items: data.postLikeList }),
     placeholderData: keepPreviousData,
   });
 
@@ -37,7 +37,7 @@ const PeriodPostLikeCard = ({ keywordId }) => {
     <article className="flex flex-col gap-6 w-1/2 h-full p-10 border-2 rounded-md">
       <span className="flex-shrink-0 bg-green-100/20 px-10 py-5 rounded-[2px]">주간 좋아요 수</span>
       <div className="flex-col-center">
-        <BarChart chartData={chartData} />
+        <LineChart chartData={chartData} />
         <PeriodPagination
           chartData={chartData}
           setCursorId={setCursorId}

--- a/src/components/Card/Chart/PeriodPostLikeCard.jsx
+++ b/src/components/Card/Chart/PeriodPostLikeCard.jsx
@@ -1,0 +1,55 @@
+import { useState } from "react";
+
+import asyncGetPostLikeList from "../../../api/keyword/asyncGetPostLikeList";
+import { getCursorDate } from "../../../utils/date";
+import BarChart from "../../Chart/BarChart";
+import PeriodPagination from "../../Pagination/PeriodPagination";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import PropTypes from "prop-types";
+
+const PeriodPostLikeCard = ({ keywordId }) => {
+  const [cursorId, setCursorId] = useState(() => getCursorDate());
+
+  const {
+    data: chartData,
+    isPlaceholderData,
+    isError,
+  } = useQuery({
+    queryKey: ["postCount", keywordId, cursorId],
+    queryFn: () => asyncGetPostLikeList(keywordId, cursorId),
+    select: (data) => (data = { ...data, items: data.postLikeList }),
+    placeholderData: keepPreviousData,
+  });
+
+  if (chartData === undefined) {
+    return null;
+  }
+
+  if (isError || chartData?.message?.includes("Error occured")) {
+    return (
+      <div className="w-1/2 h-full p-10 border-2 rounded-md flex justify-center items-center">
+        주간 좋아요 수 차트를 불러오는 데 실패했습니다.
+      </div>
+    );
+  }
+
+  return (
+    <article className="flex flex-col gap-6 w-1/2 h-full p-10 border-2 rounded-md">
+      <span className="flex-shrink-0 bg-green-100/20 px-10 py-5 rounded-[2px]">주간 좋아요 수</span>
+      <div className="flex-col-center">
+        <BarChart chartData={chartData} />
+        <PeriodPagination
+          chartData={chartData}
+          setCursorId={setCursorId}
+          isPlaceholderData={isPlaceholderData}
+        />
+      </div>
+    </article>
+  );
+};
+
+export default PeriodPostLikeCard;
+
+PeriodPostLikeCard.propTypes = {
+  keywordId: PropTypes.string.isRequired,
+};

--- a/src/components/Card/Chart/PeriodPostLikeCard.jsx
+++ b/src/components/Card/Chart/PeriodPostLikeCard.jsx
@@ -28,14 +28,14 @@ const PeriodPostLikeCard = ({ keywordId }) => {
   if (isError || chartData?.message?.includes("Error occured")) {
     return (
       <div className="w-1/2 h-full p-10 border-2 rounded-md flex justify-center items-center">
-        주간 좋아요 수 차트를 불러오는 데 실패했습니다.
+        주간 공감 수 차트를 불러오는 데 실패했습니다.
       </div>
     );
   }
 
   return (
     <article className="flex flex-col gap-6 w-1/2 h-full p-10 border-2 rounded-md">
-      <span className="flex-shrink-0 bg-green-100/20 px-10 py-5 rounded-[2px]">주간 좋아요 수</span>
+      <span className="flex-shrink-0 bg-green-100/20 px-10 py-5 rounded-[2px]">주간 공감 수</span>
       <div className="flex-col-center">
         <LineChart chartData={chartData} />
         <PeriodPagination

--- a/src/components/Card/Chart/TodayPostCountCard.jsx
+++ b/src/components/Card/Chart/TodayPostCountCard.jsx
@@ -23,7 +23,7 @@ const TodayPostCountCard = ({ keywordId }) => {
     );
   }
 
-  const noDiff = Number(chartData?.diffPostCount) === 0;
+  const isEqual = Number(chartData?.diffPostCount) === 0;
   const greaterThanYesterday = Number(chartData.diffPostCount) > 0;
   const lessThanYesterday = Number(chartData.diffPostCount) < 0;
 
@@ -32,11 +32,11 @@ const TodayPostCountCard = ({ keywordId }) => {
       <span className="bg-green-100/20 px-10 py-5 rounded-[2px]">오늘의 게시물</span>
       <div className="flex flex-col gap-10 h-full">
         <p className="flex justify-center">
-          {noDiff && <EndashIcon className="size-90" />}
+          {isEqual && <EndashIcon className="size-90" />}
           {greaterThanYesterday && <UpwardArrowIcon className="size-90" />}
           {lessThanYesterday && <DownwardArrowIcon className="size-90" />}
           <p className="text-50 justify-center items-center pt-8">
-            {!noDiff && chartData.diffPostCount}
+            {!isEqual && chartData.diffPostCount}
           </p>
         </p>
         <span className="flex-center text-120">{chartData.todayPostCount}</span>

--- a/src/components/Card/Chart/TodayPostCountCard.jsx
+++ b/src/components/Card/Chart/TodayPostCountCard.jsx
@@ -35,6 +35,9 @@ const TodayPostCountCard = ({ keywordId }) => {
           {noDiff && <EndashIcon className="size-90" />}
           {greaterThanYesterday && <UpwardArrowIcon className="size-90" />}
           {lessThanYesterday && <DownwardArrowIcon className="size-90" />}
+          <p className="text-50 justify-center items-center pt-8">
+            {!noDiff && chartData.diffPostCount}
+          </p>
         </p>
         <span className="flex-center text-120">{chartData.todayPostCount}</span>
       </div>

--- a/src/components/Card/Post/PostCard.jsx
+++ b/src/components/Card/Post/PostCard.jsx
@@ -29,11 +29,11 @@ const PostCard = ({
       <div className="flex justify-between items-center w-full">
         <div className="flex items-center gap-10 ">
           <span className="text-slate-500 text-14">
-            좋아요
+            공감
             <span className="text-slate-900"> {likeCount}</span>
           </span>
           <span className="text-slate-500 text-14">
-            댓글수
+            댓글
             <span className="text-slate-900"> {commentCount}</span>
           </span>
           <span className="text-slate-500 text-14">

--- a/src/components/Chart/BarChart.jsx
+++ b/src/components/Chart/BarChart.jsx
@@ -1,0 +1,56 @@
+import { Bar } from "react-chartjs-2";
+
+import { CHART_COLOR } from "../../config/constants";
+import { changeMonthDateFormat } from "../../utils/date";
+import {
+  BarElement,
+  CategoryScale,
+  Chart as ChartJS,
+  LinearScale,
+  PointElement,
+  Tooltip,
+} from "chart.js";
+import PropTypes from "prop-types";
+
+ChartJS.register(CategoryScale, LinearScale, PointElement, BarElement, Tooltip);
+
+const BarChart = ({ chartData }) => {
+  const data = {
+    labels: chartData.dates.map((date) => changeMonthDateFormat(date)),
+    datasets: [
+      {
+        label: chartData.keyword,
+        data: chartData.items,
+        borderColor: CHART_COLOR[0],
+        backgroundColor: CHART_COLOR[0],
+      },
+    ],
+  };
+
+  const options = {
+    responsive: true,
+    scales: {
+      y: {
+        beginAtZero: true,
+      },
+    },
+  };
+
+  return <Bar options={options} data={data} />;
+};
+
+export default BarChart;
+
+BarChart.propTypes = {
+  chartData: PropTypes.shape({
+    keywordId: PropTypes.string,
+    keyword: PropTypes.string,
+    cursorId: PropTypes.string,
+    dates: PropTypes.arrayOf(PropTypes.string),
+    items: PropTypes.arrayOf(PropTypes.number),
+    previousCursorId: PropTypes.string,
+    nextCursorId: PropTypes.string,
+    hasPrevious: PropTypes.bool,
+    hasNext: PropTypes.bool,
+  }).isRequired,
+};

--- a/src/components/Chart/LineChart.jsx
+++ b/src/components/Chart/LineChart.jsx
@@ -20,7 +20,7 @@ const LineChart = ({ chartData }) => {
     datasets: [
       {
         label: chartData.keyword,
-        data: chartData.postCountList,
+        data: chartData.items,
         borderColor: CHART_COLOR[0],
         backgroundColor: CHART_COLOR[0],
       },
@@ -47,7 +47,7 @@ LineChart.propTypes = {
     keyword: PropTypes.string,
     cursorId: PropTypes.string,
     dates: PropTypes.arrayOf(PropTypes.string),
-    postCountList: PropTypes.arrayOf(PropTypes.number),
+    items: PropTypes.arrayOf(PropTypes.number),
     previousCursorId: PropTypes.string,
     nextCursorId: PropTypes.string,
     hasPrevious: PropTypes.bool,

--- a/src/pages/KeywordPage.jsx
+++ b/src/pages/KeywordPage.jsx
@@ -3,6 +3,7 @@ import { useParams } from "react-router-dom";
 
 import asyncGetUserGroup from "../api/group/asyncGetUserGroup";
 import asyncGetKeyword from "../api/keyword/asyncGetKeyword";
+import PeriodPostCommentCard from "../components/Card/Chart/PeriodPostCommentCard";
 import PeriodPostCountCard from "../components/Card/Chart/PeriodPostCountCard";
 import TodayPostCountCard from "../components/Card/Chart/TodayPostCountCard";
 import PostCardList from "../components/Card/Post/PostCardList";
@@ -85,6 +86,9 @@ const KeywordPage = () => {
                   <div className="flex gap-10 w-full">
                     <TodayPostCountCard keywordId={keywordId} />
                     <PeriodPostCountCard keywordId={keywordId} />
+                  </div>
+                  <div className="flex gap-10 w-full">
+                    <PeriodPostCommentCard keywordId={keywordId} />
                   </div>
                 </div>
               ) : (

--- a/src/pages/KeywordPage.jsx
+++ b/src/pages/KeywordPage.jsx
@@ -5,6 +5,7 @@ import asyncGetUserGroup from "../api/group/asyncGetUserGroup";
 import asyncGetKeyword from "../api/keyword/asyncGetKeyword";
 import PeriodPostCommentCard from "../components/Card/Chart/PeriodPostCommentCard";
 import PeriodPostCountCard from "../components/Card/Chart/PeriodPostCountCard";
+import PeriodPostLikeCard from "../components/Card/Chart/PeriodPostLikeCard";
 import TodayPostCountCard from "../components/Card/Chart/TodayPostCountCard";
 import PostCardList from "../components/Card/Post/PostCardList";
 import DashboardHeader from "../components/Header/DashboardHeader";
@@ -88,6 +89,7 @@ const KeywordPage = () => {
                     <PeriodPostCountCard keywordId={keywordId} />
                   </div>
                   <div className="flex gap-10 w-full">
+                    <PeriodPostLikeCard keywordId={keywordId} />
                     <PeriodPostCommentCard keywordId={keywordId} />
                   </div>
                 </div>


### PR DESCRIPTION
## 이슈

- close #26 

## 구현 화면
![스크린샷 2024-11-15 오후 12 28 09](https://github.com/user-attachments/assets/cc21aa5a-93b5-4c06-a632-7f93f6fd7b9b)




## 상세 설명
- 일요일을 시작으로 토요일까지를 주간으로 정의하였습니다.

### 주간 좋아요 수 차트
- 일주일 동안의 게시물 좋아요 수 변화를 라인 차트로 표시합니다.
- 하단의 페이지네이션을 통해 지난주, 다음주의 게시물 수 또한 차트에 표시됩니다.

### 주간 댓글 수 차트
- 일주일 동안의 게시물 댓글 수 변화를 바 차트로 표시합니다.
- 하단의 페이지네이션을 통해 지난주, 다음주의 게시물 수 또한 차트에 표시됩니다.

## 참고사항
- 화면의 다양함을 위해 댓글 수 차트는 바 차트로 구현했습니다.


## PR 체크 사항

- [x] conflict를 모두 해결하였습니다.
- [x] 가장 최신 dev 브랜치를 pull 하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] `console.log`나 주석 여부를 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
- [x] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!

## 리뷰 반영사항
- 이중 부정될 수 있는 변수명 변경하였습니다.
- like에 대한 명칭을 "좋아요"에서 "공감"으로 변경하였습니다.

## 리뷰 마감 기한
2024년 11월 15일 **12시**까지