### PR TITLE
Fix: 키워드 등록 모달에서 새로운 그룹 생성시 생성하기 버튼 동작하지 않는 이슈 수정

### DIFF
--- a/src/components/Modal/CreateKeywordModal.jsx
+++ b/src/components/Modal/CreateKeywordModal.jsx
@@ -64,19 +64,27 @@ const CreateKeywordModal = ({ createType, selectedGroupId, selectedGroupName }) 
     const keywordValue = inputValue.keyword.trim();
     const newGroupValue = inputValue.newGroup.trim();
 
-    if (keywordValue === "" || selectedGroup.name === "") {
-      if (keywordValue === "") {
-        setErrorMessage((prev) => ({ ...prev, keyword: ERROR_MESSAGE.KEYWORD_EMPTY_INPUT_VALUE }));
+    if (isCreatingNewGroup) {
+      if (newGroupValue === "") {
+        setErrorMessage((prev) => ({
+          ...prev,
+          newGroup: ERROR_MESSAGE.NEW_GROUP_EMPTY_INPUT_VALUE,
+        }));
+        return;
       }
-      if (selectedGroup.name === "") {
-        setErrorMessage((prev) => ({ ...prev, group: ERROR_MESSAGE.MUST_GROUP_SELECT }));
+    } else {
+      if (keywordValue === "" || selectedGroup.name === "") {
+        if (keywordValue === "") {
+          setErrorMessage((prev) => ({
+            ...prev,
+            keyword: ERROR_MESSAGE.KEYWORD_EMPTY_INPUT_VALUE,
+          }));
+        }
+        if (selectedGroup.name === "") {
+          setErrorMessage((prev) => ({ ...prev, group: ERROR_MESSAGE.MUST_GROUP_SELECT }));
+        }
+        return;
       }
-      return;
-    }
-
-    if (isCreatingNewGroup && newGroupValue === "") {
-      setErrorMessage((prev) => ({ ...prev, newGroup: ERROR_MESSAGE.NEW_GROUP_EMPTY_INPUT_VALUE }));
-      return;
     }
 
     const keywordInfo = {


### PR DESCRIPTION
## 상세 설명
- 키워드 등록 모달에서 새로운 그룹을 생성한 후 키워드 등록했을 경우, 생성하기 버튼이 동작하지 않는 이슈를 수정했습니다.
-> 유효성을 검사하는 로직에서 새로운 그룹 여부를 확인하는 로직이 기존 그룹의 이름이 빈문자열인지 확인하는 로직보다 하단에 위치하여 발생한 문제로 새로운 그룹 여부를 먼저 확인하는 것으로 수정하였습니다.

## 참고사항

- 새로운 그룹 생성 외엔 기존 그룹에 키워드가 추가하는 로직은 정상적으로 동작하고 있었습니다.


## PR 체크 사항

- [x] conflict를 모두 해결하였습니다.
- [x] 가장 최신 dev 브랜치를 pull 하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] `console.log`나 주석 여부를 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
- [x] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!


