### PR TITLE
Feat: 그룹 대시보드 게시물 수, 좋아요 수, 댓글 수 차트 구현

### DIFF
--- a/src/api/group/asyncGetGroupCommentCountList.js
+++ b/src/api/group/asyncGetGroupCommentCountList.js
@@ -1,9 +1,9 @@
 import fetchHandler from "..";
 import { BASE_URL } from "../../config/constants";
 
-const asyncGetTotalPostCountList = async (cursorId = "", groupId) => {
+const asyncGetGroupCommentCountList = async (cursorId = "", groupId) => {
   const fetchInfo = {
-    url: `${BASE_URL}/posts/groups/${groupId}/postCount`,
+    url: `${BASE_URL}/posts/groups/${groupId}/commentCount`,
     params: `?cursorId=${cursorId}`,
   };
 
@@ -12,4 +12,4 @@ const asyncGetTotalPostCountList = async (cursorId = "", groupId) => {
   return response;
 };
 
-export default asyncGetTotalPostCountList;
+export default asyncGetGroupCommentCountList;

--- a/src/api/group/asyncGetGroupLikeCountList.js
+++ b/src/api/group/asyncGetGroupLikeCountList.js
@@ -1,0 +1,15 @@
+import fetchHandler from "..";
+import { BASE_URL } from "../../config/constants";
+
+const asyncGetGroupLikeCountList = async (cursorId = "", groupId) => {
+  const fetchInfo = {
+    url: `${BASE_URL}/posts/groups/${groupId}/likeCount`,
+    params: `?cursorId=${cursorId}`,
+  };
+
+  const response = await fetchHandler(fetchInfo);
+
+  return response;
+};
+
+export default asyncGetGroupLikeCountList;

--- a/src/api/group/asyncGetGroupPostCountList.js
+++ b/src/api/group/asyncGetGroupPostCountList.js
@@ -1,0 +1,15 @@
+import fetchHandler from "..";
+import { BASE_URL } from "../../config/constants";
+
+const asyncGetGroupPostCountList = async (cursorId = "", groupId) => {
+  const fetchInfo = {
+    url: `${BASE_URL}/posts/groups/${groupId}/postCount`,
+    params: `?cursorId=${cursorId}`,
+  };
+
+  const response = await fetchHandler(fetchInfo);
+
+  return response;
+};
+
+export default asyncGetGroupPostCountList;

--- a/src/api/group/asyncGetTotalPostCountList.js
+++ b/src/api/group/asyncGetTotalPostCountList.js
@@ -1,0 +1,15 @@
+import fetchHandler from "..";
+import { BASE_URL } from "../../config/constants";
+
+const asyncGetTotalPostCountList = async (cursorId = "", groupId) => {
+  const fetchInfo = {
+    url: `${BASE_URL}/posts/groups/${groupId}/postCount`,
+    params: `?cursorId=${cursorId}`,
+  };
+
+  const response = await fetchHandler(fetchInfo);
+
+  return response;
+};
+
+export default asyncGetTotalPostCountList;

--- a/src/components/Card/Chart/GroupPeriodPostCountCard.jsx
+++ b/src/components/Card/Chart/GroupPeriodPostCountCard.jsx
@@ -27,9 +27,11 @@ const GroupPeriodPostCountCard = ({ groupChartType, groupId, hasUserUid }) => {
     isGroupPostCountDataError || groupPostCountData?.message?.includes("Error occured");
 
   if (isError) {
-    <article className="flex-col-center w-full h-full border-2 rounded-md">
-      에러가 발생하였습니다. 잠시 후 다시 시도해주시기 바랍니다.
-    </article>;
+    return (
+      <article className="flex-col-center w-full h-full border-2 rounded-md">
+        에러가 발생하였습니다. 잠시 후 다시 시도해주시기 바랍니다.
+      </article>
+    );
   }
 
   if (groupPostCountData === undefined) {
@@ -38,10 +40,10 @@ const GroupPeriodPostCountCard = ({ groupChartType, groupId, hasUserUid }) => {
 
   return (
     <article className="flex flex-col gap-6 w-full h-full p-10 border-2 rounded-md">
-      <div className="flex-shrink-0 bg-green-100/20 px-10 py-5 rounded-[2px]">
+      <span className="flex-shrink-0 bg-green-100/20 px-10 py-5 rounded-[2px]">
         {groupChartType}
-      </div>
-      <div className="flex-col-center h-full">
+      </span>
+      <div className="flex-col-center h-full gap-5">
         <GroupLineChart groupChartType={groupChartType} chartData={groupPostCountData} />
         <GroupPeriodPagination
           chartData={groupPostCountData}

--- a/src/components/Card/Chart/GroupPeriodPostCountCard.jsx
+++ b/src/components/Card/Chart/GroupPeriodPostCountCard.jsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 
 import asyncGetTotalPostCountList from "../../../api/group/asyncGetTotalPostCountList";
+import { GROUP_CHART_TYPE } from "../../../config/constants";
 import GroupLineChart from "../../Chart/GroupLineChart";
 import GroupPeriodPagination from "../../Pagination/GroupPeriodPagination";
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
@@ -39,7 +40,9 @@ const GroupPeriodPostCountCard = ({ groupChartType, groupId, hasUserUid }) => {
   }
 
   return (
-    <article className="flex flex-col gap-6 w-full h-full p-10 border-2 rounded-md">
+    <article
+      className={`flex flex-col gap-6 h-full p-10 border-2 rounded-md ${groupChartType === GROUP_CHART_TYPE.POST ? "w-full" : "w-1/2"}`}
+    >
       <span className="flex-shrink-0 bg-green-100/20 px-10 py-5 rounded-[2px]">
         {groupChartType}
       </span>

--- a/src/components/Card/Chart/GroupPeriodPostCountCard.jsx
+++ b/src/components/Card/Chart/GroupPeriodPostCountCard.jsx
@@ -1,6 +1,8 @@
 import { useState } from "react";
 
-import asyncGetTotalPostCountList from "../../../api/group/asyncGetTotalPostCountList";
+import asyncGetGroupCommentCountList from "../../../api/group/asyncGetGroupCommentCountList";
+import asyncGetGroupLikeCountList from "../../../api/group/asyncGetGroupLikeCountList";
+import asyncGetGroupPostCountList from "../../../api/group/asyncGetGroupPostCountList";
 import { GROUP_CHART_TYPE } from "../../../config/constants";
 import GroupLineChart from "../../Chart/GroupLineChart";
 import GroupPeriodPagination from "../../Pagination/GroupPeriodPagination";
@@ -11,6 +13,19 @@ const GroupPeriodPostCountCard = ({ groupChartType, groupId, hasUserUid }) => {
   const [cursorId, setCursorId] = useState("");
 
   const hasGroupId = !!groupId;
+  let queryFunction;
+
+  switch (groupChartType) {
+    case GROUP_CHART_TYPE.POST:
+      queryFunction = asyncGetGroupPostCountList;
+      break;
+    case GROUP_CHART_TYPE.LIKE:
+      queryFunction = asyncGetGroupLikeCountList;
+      break;
+    case GROUP_CHART_TYPE.COMMENT:
+      queryFunction = asyncGetGroupCommentCountList;
+      break;
+  }
 
   const {
     data: groupPostCountData,
@@ -18,7 +33,7 @@ const GroupPeriodPostCountCard = ({ groupChartType, groupId, hasUserUid }) => {
     isPlaceholderData,
   } = useQuery({
     queryKey: ["groupPostCount", cursorId, groupId, groupChartType],
-    queryFn: () => asyncGetTotalPostCountList(cursorId, groupId),
+    queryFn: () => queryFunction(cursorId, groupId),
     placeholderData: keepPreviousData,
     enabled: hasUserUid && hasGroupId,
     staleTime: 5 * 1000,

--- a/src/components/Card/Chart/GroupPeriodPostCountCard.jsx
+++ b/src/components/Card/Chart/GroupPeriodPostCountCard.jsx
@@ -1,0 +1,44 @@
+import GroupLineChart from "../../Chart/GroupLineChart";
+import GroupPeriodPagination from "../../Pagination/GroupPeriodPagination";
+import PropTypes from "prop-types";
+
+const GroupPeriodPostCountCard = ({ groupPostCountData, setCursorId, isPlaceholderData }) => {
+  return (
+    <article className="flex flex-col gap-6 w-full h-full p-10 border-2 rounded-md">
+      <span className="flex-shrink-0 bg-green-100/20 px-10 py-5 rounded-[2px]">주간 게시물 수</span>
+      <div className="flex-col-center">
+        <GroupLineChart chartData={groupPostCountData} />
+        <GroupPeriodPagination
+          chartData={groupPostCountData}
+          setCursorId={setCursorId}
+          isPlaceholderData={isPlaceholderData}
+        />
+      </div>
+    </article>
+  );
+};
+
+export default GroupPeriodPostCountCard;
+
+GroupPeriodPostCountCard.propTypes = {
+  groupPostCountData: PropTypes.shape({
+    groupId: PropTypes.string.isRequired,
+    keywordIdList: PropTypes.arrayOf(PropTypes.string).isRequired,
+    items: PropTypes.arrayOf(
+      PropTypes.shape({
+        name: PropTypes.string,
+        postCountList: PropTypes.arrayOf(PropTypes.number),
+        likeCountList: PropTypes.arrayOf(PropTypes.number),
+        commentCountList: PropTypes.arrayOf(PropTypes.number),
+        dates: PropTypes.arrayOf(PropTypes.string),
+      })
+    ).isRequired,
+    hasPrevious: PropTypes.bool.isRequired,
+    hasNext: PropTypes.bool.isRequired,
+    cursorId: PropTypes.string.isRequired,
+    previousCursorId: PropTypes.string.isRequired,
+    nextCursorId: PropTypes.string.isRequired,
+  }).isRequired,
+  setCursorId: PropTypes.func.isRequired,
+  isPlaceholderData: PropTypes.bool.isRequired,
+};

--- a/src/components/Card/Chart/GroupPeriodPostCountCard.jsx
+++ b/src/components/Card/Chart/GroupPeriodPostCountCard.jsx
@@ -1,13 +1,48 @@
+import { useState } from "react";
+
+import asyncGetTotalPostCountList from "../../../api/group/asyncGetTotalPostCountList";
 import GroupLineChart from "../../Chart/GroupLineChart";
 import GroupPeriodPagination from "../../Pagination/GroupPeriodPagination";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import PropTypes from "prop-types";
 
-const GroupPeriodPostCountCard = ({ groupPostCountData, setCursorId, isPlaceholderData }) => {
+const GroupPeriodPostCountCard = ({ groupChartType, groupId, hasUserUid }) => {
+  const [cursorId, setCursorId] = useState("");
+
+  const hasGroupId = !!groupId;
+
+  const {
+    data: groupPostCountData,
+    isError: isGroupPostCountDataError,
+    isPlaceholderData,
+  } = useQuery({
+    queryKey: ["groupPostCount", cursorId, groupId, groupChartType],
+    queryFn: () => asyncGetTotalPostCountList(cursorId, groupId),
+    placeholderData: keepPreviousData,
+    enabled: hasUserUid && hasGroupId,
+    staleTime: 5 * 1000,
+  });
+
+  const isError =
+    isGroupPostCountDataError || groupPostCountData?.message?.includes("Error occured");
+
+  if (isError) {
+    <article className="flex-col-center w-full h-full border-2 rounded-md">
+      에러가 발생하였습니다. 잠시 후 다시 시도해주시기 바랍니다.
+    </article>;
+  }
+
+  if (groupPostCountData === undefined) {
+    return null;
+  }
+
   return (
     <article className="flex flex-col gap-6 w-full h-full p-10 border-2 rounded-md">
-      <span className="flex-shrink-0 bg-green-100/20 px-10 py-5 rounded-[2px]">주간 게시물 수</span>
-      <div className="flex-col-center">
-        <GroupLineChart chartData={groupPostCountData} />
+      <div className="flex-shrink-0 bg-green-100/20 px-10 py-5 rounded-[2px]">
+        {groupChartType}
+      </div>
+      <div className="flex-col-center h-full">
+        <GroupLineChart groupChartType={groupChartType} chartData={groupPostCountData} />
         <GroupPeriodPagination
           chartData={groupPostCountData}
           setCursorId={setCursorId}
@@ -21,24 +56,7 @@ const GroupPeriodPostCountCard = ({ groupPostCountData, setCursorId, isPlacehold
 export default GroupPeriodPostCountCard;
 
 GroupPeriodPostCountCard.propTypes = {
-  groupPostCountData: PropTypes.shape({
-    groupId: PropTypes.string.isRequired,
-    keywordIdList: PropTypes.arrayOf(PropTypes.string).isRequired,
-    items: PropTypes.arrayOf(
-      PropTypes.shape({
-        name: PropTypes.string,
-        postCountList: PropTypes.arrayOf(PropTypes.number),
-        likeCountList: PropTypes.arrayOf(PropTypes.number),
-        commentCountList: PropTypes.arrayOf(PropTypes.number),
-        dates: PropTypes.arrayOf(PropTypes.string),
-      })
-    ).isRequired,
-    hasPrevious: PropTypes.bool.isRequired,
-    hasNext: PropTypes.bool.isRequired,
-    cursorId: PropTypes.string.isRequired,
-    previousCursorId: PropTypes.string.isRequired,
-    nextCursorId: PropTypes.string.isRequired,
-  }).isRequired,
-  setCursorId: PropTypes.func.isRequired,
-  isPlaceholderData: PropTypes.bool.isRequired,
+  groupChartType: PropTypes.string.isRequired,
+  groupId: PropTypes.string.isRequired,
+  hasUserUid: PropTypes.bool.isRequired,
 };

--- a/src/components/Card/Chart/TodayPostCountCard.jsx
+++ b/src/components/Card/Chart/TodayPostCountCard.jsx
@@ -31,14 +31,14 @@ const TodayPostCountCard = ({ keywordId }) => {
     <article className="flex flex-col gap-40 w-[35%] h-full p-10 border-2 rounded-md flex-shrink-0">
       <span className="bg-green-100/20 px-10 py-5 rounded-[2px]">오늘의 게시물</span>
       <div className="flex flex-col gap-10 h-full">
-        <p className="flex justify-center">
+        <div className="flex justify-center">
           {isEqual && <EndashIcon className="size-90" />}
           {greaterThanYesterday && <UpwardArrowIcon className="size-90" />}
           {lessThanYesterday && <DownwardArrowIcon className="size-90" />}
           <p className="text-50 justify-center items-center pt-8">
             {!isEqual && chartData.diffPostCount}
           </p>
-        </p>
+        </div>
         <span className="flex-center text-120">{chartData.todayPostCount}</span>
       </div>
     </article>

--- a/src/components/Chart/GroupLineChart.jsx
+++ b/src/components/Chart/GroupLineChart.jsx
@@ -34,8 +34,8 @@ const GroupLineChart = ({ groupChartType, chartData }) => {
       return {
         label: name,
         data,
-        borderColor: CHART_COLOR[index],
-        backgroundColor: CHART_COLOR[index],
+        borderColor: CHART_COLOR[index % 5],
+        backgroundColor: CHART_COLOR[index % 5],
       };
     }),
   };

--- a/src/components/Chart/GroupLineChart.jsx
+++ b/src/components/Chart/GroupLineChart.jsx
@@ -48,7 +48,7 @@ const GroupLineChart = ({ groupChartType, chartData }) => {
       },
     },
     maintainAspectRatio: true,
-    aspectRatio: 3,
+    aspectRatio: 2.6,
 
     plugins: {
       legend: {

--- a/src/components/Chart/GroupLineChart.jsx
+++ b/src/components/Chart/GroupLineChart.jsx
@@ -1,6 +1,6 @@
 import { Line } from "react-chartjs-2";
 
-import { CHART_COLOR } from "../../config/constants";
+import { CHART_COLOR, GROUP_CHART_TYPE } from "../../config/constants";
 import { changeMonthDateFormat } from "../../utils/date";
 import {
   CategoryScale,
@@ -14,15 +14,25 @@ import PropTypes from "prop-types";
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip);
 
-const GroupLineChart = ({ chartData }) => {
+const GroupLineChart = ({ groupChartType, chartData }) => {
   const data = {
     labels: chartData?.items[0]?.dates?.map((date) => changeMonthDateFormat(date)),
     datasets: chartData?.items?.map((keyword, index) => {
-      const { name, postCountList } = keyword;
+      const { name, postCountList, likeCountList, commentCountList } = keyword;
+
+      let data;
+
+      if (groupChartType === GROUP_CHART_TYPE.POST) {
+        data = postCountList;
+      } else if (groupChartType === GROUP_CHART_TYPE.LIKE) {
+        data = likeCountList;
+      } else if (groupChartType === GROUP_CHART_TYPE.COMMENT) {
+        data = commentCountList;
+      }
 
       return {
         label: name,
-        data: postCountList,
+        data,
         borderColor: CHART_COLOR[index % 5],
         backgroundColor: CHART_COLOR[index % 5],
       };
@@ -44,6 +54,7 @@ const GroupLineChart = ({ chartData }) => {
 export default GroupLineChart;
 
 GroupLineChart.propTypes = {
+  groupChartType: PropTypes.string.isRequired,
   chartData: PropTypes.shape({
     groupId: PropTypes.string.isRequired,
     keywordIdList: PropTypes.arrayOf(PropTypes.string).isRequired,

--- a/src/components/Chart/GroupLineChart.jsx
+++ b/src/components/Chart/GroupLineChart.jsx
@@ -19,20 +19,18 @@ const GroupLineChart = ({ groupChartType, chartData }) => {
   const data = {
     labels: chartData?.items[0]?.dates?.map((date) => changeMonthDateFormat(date)),
     datasets: chartData?.items?.map((keyword, index) => {
-      const { name, postCountList, likeCountList, commentCountList } = keyword;
-
       let data;
 
       if (groupChartType === GROUP_CHART_TYPE.POST) {
-        data = postCountList;
+        data = keyword.postCountList;
       } else if (groupChartType === GROUP_CHART_TYPE.LIKE) {
-        data = likeCountList;
+        data = keyword.likeCountList;
       } else if (groupChartType === GROUP_CHART_TYPE.COMMENT) {
-        data = commentCountList;
+        data = keyword.commentCountList;
       }
 
       return {
-        label: name,
+        label: keyword.name,
         data,
         borderColor: CHART_COLOR[index % 5],
         backgroundColor: CHART_COLOR[index % 5],

--- a/src/components/Chart/GroupLineChart.jsx
+++ b/src/components/Chart/GroupLineChart.jsx
@@ -34,8 +34,8 @@ const GroupLineChart = ({ groupChartType, chartData }) => {
       return {
         label: name,
         data,
-        borderColor: CHART_COLOR[index % 5],
-        backgroundColor: CHART_COLOR[index % 5],
+        borderColor: CHART_COLOR[index],
+        backgroundColor: CHART_COLOR[index],
       };
     }),
   };

--- a/src/components/Chart/GroupLineChart.jsx
+++ b/src/components/Chart/GroupLineChart.jsx
@@ -1,0 +1,65 @@
+import { Line } from "react-chartjs-2";
+
+import { CHART_COLOR } from "../../config/constants";
+import { changeMonthDateFormat } from "../../utils/date";
+import {
+  CategoryScale,
+  Chart as ChartJS,
+  LineElement,
+  LinearScale,
+  PointElement,
+  Tooltip,
+} from "chart.js";
+import PropTypes from "prop-types";
+
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip);
+
+const GroupLineChart = ({ chartData }) => {
+  const data = {
+    labels: chartData?.items[0]?.dates?.map((date) => changeMonthDateFormat(date)),
+    datasets: chartData?.items?.map((keyword, index) => {
+      const { name, postCountList } = keyword;
+
+      return {
+        label: name,
+        data: postCountList,
+        borderColor: CHART_COLOR[index % 5],
+        backgroundColor: CHART_COLOR[index % 5],
+      };
+    }),
+  };
+
+  const options = {
+    responsive: true,
+    scales: {
+      y: {
+        beginAtZero: true,
+      },
+    },
+  };
+
+  return <Line options={options} data={data} />;
+};
+
+export default GroupLineChart;
+
+GroupLineChart.propTypes = {
+  chartData: PropTypes.shape({
+    groupId: PropTypes.string.isRequired,
+    keywordIdList: PropTypes.arrayOf(PropTypes.string).isRequired,
+    items: PropTypes.arrayOf(
+      PropTypes.shape({
+        name: PropTypes.string,
+        postCountList: PropTypes.arrayOf(PropTypes.number),
+        likeCountList: PropTypes.arrayOf(PropTypes.number),
+        commentCountList: PropTypes.arrayOf(PropTypes.number),
+        dates: PropTypes.arrayOf(PropTypes.string),
+      })
+    ).isRequired,
+    hasPrevious: PropTypes.bool.isRequired,
+    hasNext: PropTypes.bool.isRequired,
+    cursorId: PropTypes.string.isRequired,
+    previousCursorId: PropTypes.string.isRequired,
+    nextCursorId: PropTypes.string.isRequired,
+  }).isRequired,
+};

--- a/src/components/Chart/GroupLineChart.jsx
+++ b/src/components/Chart/GroupLineChart.jsx
@@ -9,10 +9,11 @@ import {
   LinearScale,
   PointElement,
   Tooltip,
+  plugins,
 } from "chart.js";
 import PropTypes from "prop-types";
 
-ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip);
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip, plugins);
 
 const GroupLineChart = ({ groupChartType, chartData }) => {
   const data = {
@@ -33,8 +34,8 @@ const GroupLineChart = ({ groupChartType, chartData }) => {
       return {
         label: name,
         data,
-        borderColor: CHART_COLOR[index % 5],
-        backgroundColor: CHART_COLOR[index % 5],
+        borderColor: CHART_COLOR[index],
+        backgroundColor: CHART_COLOR[index],
       };
     }),
   };
@@ -44,6 +45,29 @@ const GroupLineChart = ({ groupChartType, chartData }) => {
     scales: {
       y: {
         beginAtZero: true,
+      },
+    },
+    maintainAspectRatio: true,
+    aspectRatio: 3,
+
+    plugins: {
+      legend: {
+        display: true,
+        position: "top",
+        align: "center",
+        labels: {
+          padding: 11,
+          boxWidth: 11,
+          color: "#000000",
+          usePointStyle: false,
+          pointStyle: "circle",
+          font: {
+            family: "Pretendard",
+            size: 12,
+            lineHeight: 2,
+            weight: "normal",
+          },
+        },
       },
     },
   };

--- a/src/components/Modal/ErrorModal.jsx
+++ b/src/components/Modal/ErrorModal.jsx
@@ -18,7 +18,7 @@ const ErrorModal = ({ errorMessage }) => {
       <ModalBackground isClear={false} modalType={MODAL_TYPE.ERROR}>
         <ModalFrame isClear={false} hasCloseButton={false} modalType={MODAL_TYPE.ERROR}>
           <main className="flex flex-col gap-10 items-center">
-            <h1 className="text-16 text-red-400">{errorMessage} 😅</h1>
+            <h1 className="text-16 text-red-400">{errorMessage}</h1>
             <Button
               type="button"
               styles="flex-center px-14 py-8 font-medium border-2 border-purple-200 bg-purple-400/80 rounded-[15px] text-white text-18 hover:bg-purple-500/80"

--- a/src/components/Pagination/GroupPeriodPagination.jsx
+++ b/src/components/Pagination/GroupPeriodPagination.jsx
@@ -1,0 +1,61 @@
+import { changeDateWithDotFormat } from "../../utils/date";
+import LeftCarouselIcon from "../Icon/LeftCarouselIcon";
+import RightCarouselIcon from "../Icon/RightCarouselIcon";
+import Button from "../UI/Button";
+import PropTypes from "prop-types";
+
+const GroupPeriodPagination = ({ chartData, setCursorId, isPlaceholderData }) => {
+  const isPreviousButtonDisabled = !chartData?.hasPrevious || isPlaceholderData;
+  const isNextButtonDisabled = !chartData?.hasNext || isPlaceholderData;
+
+  return (
+    <div className="flex justify-center items-center">
+      <Button
+        styles={`z-30 px-4 h-full cursor-pointer group focus:outline-none ${isPreviousButtonDisabled && "hover:cursor-default"}`}
+        onClick={() => setCursorId(chartData?.previousCursorId)}
+        isDisabled={isPreviousButtonDisabled}
+      >
+        <LeftCarouselIcon isDisabled={isPreviousButtonDisabled} />
+      </Button>
+      <span className="text-14">
+        {changeDateWithDotFormat(chartData?.items[0]?.dates[0]) +
+          " ~ " +
+          changeDateWithDotFormat(
+            chartData?.items[0]?.dates[chartData?.items[0]?.dates.length - 1]
+          )}
+      </span>
+      <Button
+        styles={`z-30 px-4 h-full cursor-pointer group focus:outline-none ${isNextButtonDisabled && "hover:cursor-default"}`}
+        onClick={() => setCursorId(chartData?.nextCursorId)}
+        isDisabled={isNextButtonDisabled}
+      >
+        <RightCarouselIcon isDisabled={isNextButtonDisabled} />
+      </Button>
+    </div>
+  );
+};
+
+export default GroupPeriodPagination;
+
+GroupPeriodPagination.propTypes = {
+  chartData: PropTypes.shape({
+    groupId: PropTypes.string.isRequired,
+    keywordIdList: PropTypes.arrayOf(PropTypes.string).isRequired,
+    items: PropTypes.arrayOf(
+      PropTypes.shape({
+        name: PropTypes.string,
+        postCountList: PropTypes.arrayOf(PropTypes.number),
+        likeCountList: PropTypes.arrayOf(PropTypes.number),
+        commentCountList: PropTypes.arrayOf(PropTypes.number),
+        dates: PropTypes.arrayOf(PropTypes.string),
+      })
+    ).isRequired,
+    hasPrevious: PropTypes.bool.isRequired,
+    hasNext: PropTypes.bool.isRequired,
+    cursorId: PropTypes.string.isRequired,
+    previousCursorId: PropTypes.string.isRequired,
+    nextCursorId: PropTypes.string.isRequired,
+  }).isRequired,
+  setCursorId: PropTypes.func.isRequired,
+  isPlaceholderData: PropTypes.bool.isRequired,
+};

--- a/src/components/Pagination/PeriodPagination.jsx
+++ b/src/components/Pagination/PeriodPagination.jsx
@@ -27,7 +27,7 @@ const PeriodPagination = ({ chartData, setCursorId, isPlaceholderData }) => {
         onClick={() => handlePagingClick("previous")}
         disabled={isPreviousButtonDisabled}
       >
-        <LeftCarouselIcon isDisabled={!chartData?.hasPrevious || isPlaceholderData} />
+        <LeftCarouselIcon isDisabled={isPreviousButtonDisabled} />
       </button>
       <span className="text-14">
         {changeDateWithDotFormat(chartData?.dates[0]) +
@@ -40,7 +40,7 @@ const PeriodPagination = ({ chartData, setCursorId, isPlaceholderData }) => {
         onClick={() => handlePagingClick("next")}
         disabled={isNextButtonDisabled}
       >
-        <RightCarouselIcon isDisabled={!chartData?.hasNext || isPlaceholderData} />
+        <RightCarouselIcon isDisabled={isNextButtonDisabled} />
       </button>
     </div>
   );

--- a/src/components/UI/Error.jsx
+++ b/src/components/UI/Error.jsx
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 const Error = ({ errorMessage }) => {
   return (
     <main className="flex-center w-full h-full">
-      <h1 className="text-18 text-red-400">{errorMessage} 😅</h1>
+      <h1 className="text-18 text-red-400">{errorMessage}</h1>
     </main>
   );
 };

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -47,6 +47,6 @@ export const SIGNATURE_COLOR = Object.freeze({
 
 export const GROUP_CHART_TYPE = Object.freeze({
   POST: "주간 게시물 수",
-  LIKE: "주간 좋아요 수",
+  LIKE: "주간 공감 수",
   COMMENT: "주간 댓글 수",
 });

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -44,3 +44,9 @@ export const SIGNATURE_COLOR = Object.freeze({
   VIA: "#009F55",
   TO: "#00ED64",
 });
+
+export const GROUP_CHART_TYPE = Object.freeze({
+  POST: "주간 게시물 수",
+  LIKE: "주간 좋아요 수",
+  COMMENT: "주간 댓글 수",
+});

--- a/src/pages/GroupPage.jsx
+++ b/src/pages/GroupPage.jsx
@@ -1,34 +1,56 @@
+import { useState } from "react";
 import { useParams } from "react-router-dom";
 
+import asyncGetTotalPostCountList from "../api/group/asyncGetTotalPostCountList";
 import asyncGetUserGroup from "../api/group/asyncGetUserGroup";
+import GroupPeriodPostCountCard from "../components/Card/Chart/GroupPeriodPostCountCard";
 import DashboardHeader from "../components/Header/DashboardHeader";
 import DashboardSidebar from "../components/Sidebar/DashboardSidebar";
 import useNoSignInRedirect from "../hooks/useNoSignInRedirect";
 import useBoundStore from "../store/client/useBoundStore";
-import { useQuery } from "@tanstack/react-query";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
 
 const GroupPage = () => {
   useNoSignInRedirect();
 
   const { groupId } = useParams();
+  const [cursorId, setCursorId] = useState("");
 
   const setUserGroupList = useBoundStore((state) => state.setUserGroupList);
   const userUid = useBoundStore((state) => state.userInfo.uid);
+  const hasGroupId = !!groupId;
   const hasUserUid = !!userUid;
 
   const { data: userGroupList, isError: isUserGroupListError } = useQuery({
     queryKey: ["userGroupList"],
     queryFn: () => asyncGetUserGroup(userUid),
     enabled: hasUserUid,
+    staleTime: 3 * 1000,
   });
 
-  const isError = isUserGroupListError || userGroupList?.message?.includes("Error occured");
+  const {
+    data: groupPostCountData,
+    isError: isGroupPostCountDataError,
+    isPlaceholderData,
+  } = useQuery({
+    queryKey: ["groupPostCount", cursorId, groupId],
+    queryFn: () => asyncGetTotalPostCountList(cursorId, groupId),
+    placeholderData: keepPreviousData,
+    enabled: hasUserUid && hasGroupId,
+    staleTime: 5 * 1000,
+  });
+
+  const isError =
+    isUserGroupListError ||
+    isGroupPostCountDataError ||
+    userGroupList?.message?.includes("Error occured") ||
+    groupPostCountData?.message?.includes("Error occured");
 
   if (userGroupList?.groupListLength > 0 && userGroupList?.groupListResult?.length > 0) {
     setUserGroupList(userGroupList?.groupListResult);
   }
 
-  if (userGroupList === undefined) {
+  if (userGroupList === undefined || groupPostCountData === undefined) {
     return null;
   }
 
@@ -37,11 +59,21 @@ const GroupPage = () => {
       <DashboardSidebar userGroupList={userGroupList?.groupListResult} groupId={groupId} />
       <section className="w-full h-full flex flex-col justify-start">
         <DashboardHeader userGroupList={userGroupList?.groupListResult} groupId={groupId} />
-        {isError && (
-          <div className="flex flex-center w-full h-full">
-            에러가 발생하였습니다. 잠시 후 다시 시도해주시기 바랍니다.
-          </div>
-        )}
+        <article className="flex flex-col border-r-2 border-slate-200/80 shadow-sm h-full">
+          {isError ? (
+            <div className="flex flex-center w-full h-full">
+              에러가 발생하였습니다. 잠시 후 다시 시도해주시기 바랍니다.
+            </div>
+          ) : (
+            <div className="flex flex-col p-10 w-full h-full">
+              <GroupPeriodPostCountCard
+                groupPostCountData={groupPostCountData}
+                setCursorId={setCursorId}
+                isPlaceholderData={isPlaceholderData}
+              />
+            </div>
+          )}
+        </article>
       </section>
     </main>
   );

--- a/src/pages/GroupPage.jsx
+++ b/src/pages/GroupPage.jsx
@@ -25,14 +25,14 @@ const GroupPage = () => {
     staleTime: 3 * 1000,
   });
 
-  const isError =
-    isUserGroupListError ||
-    userGroupList?.message?.includes("Error occured");
+  const isError = isUserGroupListError || userGroupList?.message?.includes("Error occured");
 
   if (isError) {
-    <main className="flex flex-center mx-auto w-full h-screen max-w-1440">
-      에러가 발생하였습니다. 잠시 후 다시 시도해주시기 바랍니다.
-    </main>;
+    return (
+      <main className="flex flex-center mx-auto w-full h-screen max-w-1440">
+        에러가 발생하였습니다. 잠시 후 다시 시도해주시기 바랍니다.
+      </main>
+    );
   }
 
   if (userGroupList === undefined) {

--- a/src/pages/GroupPage.jsx
+++ b/src/pages/GroupPage.jsx
@@ -30,7 +30,7 @@ const GroupPage = () => {
   if (isError) {
     return (
       <main className="flex flex-center mx-auto w-full h-screen max-w-1440">
-        에러가 발생하였습니다. 잠시 후 다시 시도해주시기 바랍니다.
+        차트를 불러오는데 실패했습니다. 잠시 후 다시 시도해주시기 바랍니다.
       </main>
     );
   }

--- a/src/pages/GroupPage.jsx
+++ b/src/pages/GroupPage.jsx
@@ -25,7 +25,9 @@ const GroupPage = () => {
     staleTime: 3 * 1000,
   });
 
-  const isError = isUserGroupListError || userGroupList?.message?.includes("Error occured");
+  const isError =
+    isUserGroupListError ||
+    userGroupList?.message?.includes("Error occured");
 
   if (isError) {
     <main className="flex flex-center mx-auto w-full h-screen max-w-1440">

--- a/src/pages/GroupPage.jsx
+++ b/src/pages/GroupPage.jsx
@@ -46,7 +46,7 @@ const GroupPage = () => {
       <DashboardSidebar userGroupList={userGroupList?.groupListResult} groupId={groupId} />
       <section className="flex flex-col justify-start w-full">
         <DashboardHeader userGroupList={userGroupList?.groupListResult} groupId={groupId} />
-        <article className="flex flex-col border-r-2 border-slate-200/80 shadow-sm h-full mb-30">
+        <article className="flex flex-col border-l-1 border-b-2 border-r-2 border-slate-200/80 shadow-md h-full mb-30">
           <div className="flex flex-col gap-10 p-10 w-full h-full">
             <GroupPeriodPostCountCard
               groupChartType={GROUP_CHART_TYPE.POST}

--- a/src/pages/GroupPage.jsx
+++ b/src/pages/GroupPage.jsx
@@ -46,7 +46,7 @@ const GroupPage = () => {
       <DashboardSidebar userGroupList={userGroupList?.groupListResult} groupId={groupId} />
       <section className="flex flex-col justify-start w-full">
         <DashboardHeader userGroupList={userGroupList?.groupListResult} groupId={groupId} />
-        <article className="flex flex-col border-l-1 border-b-2 border-r-2 border-slate-200/80 shadow-md h-full mb-30">
+        <article className="flex flex-col border-l-1 border-b-2 border-r-2 border-slate-200/80 shadow-md w-full h-full mb-30">
           <div className="flex flex-col gap-10 p-10 w-full h-full">
             <GroupPeriodPostCountCard
               groupChartType={GROUP_CHART_TYPE.POST}


### PR DESCRIPTION
## 이슈

- close #25 
- close #27 

## 구현 화면

![image](https://github.com/user-attachments/assets/fcb1192c-ebd2-4530-9b7b-49a6a106b316)

## 상세 설명

- 재사용성을 위하여 3개의 그룹 차트 카드가 동일한 차트 카드 컴포넌트를 사용하되, 아래와 같이 다른 차트 타입 임을 알려주기 위해 각기 다른 Props를 내려주었습니다. 그리고 queryKey에 groupChartType을 추가하였습니다.
```js
export const GROUP_CHART_TYPE = Object.freeze({
  POST: "주간 게시물 수",
  LIKE: "주간 좋아요 수",
  COMMENT: "주간 댓글 수",
});
```
- `chart.js`의 plugins를 사용하여 범례 구현하였습니다. 아무래도 여러 키워드의 색깔을 한 눈에 구분하기 위해 필요해보였습니다.

## 참고사항

- 차트의 가로, 세로 크기 조정이 어려웠는데, options에 `aspectRatio`를 통해 조정이 쉽게 가능하다는 것을 알았습니다. 참고 부탁드려요.

## PR 체크 사항

- [x] conflict를 모두 해결하였습니다.
- [x] 가장 최신 dev 브랜치를 pull 하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] `console.log`나 주석 여부를 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
- [x] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!
- [x] `API 명세서`를 확인하였으며 동기화 하였습니다.

## 리뷰 반영사항

- 미사용 파일 삭제
- 에러 태그 문구 변경
- 차트 타입명 변경

## PR 리뷰 마감 시간

- 2024년 11월 15일 오전