### PR TITLE
Feat: 포함/제외 태그 필터링 UI

### DIFF
--- a/src/api/group/asyncGetGroupCommentCountList.js
+++ b/src/api/group/asyncGetGroupCommentCountList.js
@@ -1,0 +1,15 @@
+import fetchHandler from "..";
+import { BASE_URL } from "../../config/constants";
+
+const asyncGetGroupCommentCountList = async (cursorId = "", groupId) => {
+  const fetchInfo = {
+    url: `${BASE_URL}/posts/groups/${groupId}/commentCount`,
+    params: `?cursorId=${cursorId}`,
+  };
+
+  const response = await fetchHandler(fetchInfo);
+
+  return response;
+};
+
+export default asyncGetGroupCommentCountList;

--- a/src/api/group/asyncGetGroupLikeCountList.js
+++ b/src/api/group/asyncGetGroupLikeCountList.js
@@ -1,0 +1,15 @@
+import fetchHandler from "..";
+import { BASE_URL } from "../../config/constants";
+
+const asyncGetGroupLikeCountList = async (cursorId = "", groupId) => {
+  const fetchInfo = {
+    url: `${BASE_URL}/posts/groups/${groupId}/likeCount`,
+    params: `?cursorId=${cursorId}`,
+  };
+
+  const response = await fetchHandler(fetchInfo);
+
+  return response;
+};
+
+export default asyncGetGroupLikeCountList;

--- a/src/api/group/asyncGetGroupPostCountList.js
+++ b/src/api/group/asyncGetGroupPostCountList.js
@@ -1,0 +1,15 @@
+import fetchHandler from "..";
+import { BASE_URL } from "../../config/constants";
+
+const asyncGetGroupPostCountList = async (cursorId = "", groupId) => {
+  const fetchInfo = {
+    url: `${BASE_URL}/posts/groups/${groupId}/postCount`,
+    params: `?cursorId=${cursorId}`,
+  };
+
+  const response = await fetchHandler(fetchInfo);
+
+  return response;
+};
+
+export default asyncGetGroupPostCountList;

--- a/src/api/keyword/asyncGetPostCommentList.js
+++ b/src/api/keyword/asyncGetPostCommentList.js
@@ -1,0 +1,15 @@
+import fetchHandler from "..";
+import { BASE_URL } from "../../config/constants";
+
+const asyncGetPostLikeList = async (keywordId, cursorId) => {
+  const fetchInfo = {
+    url: `${BASE_URL}/posts/keywords/${keywordId}/postComment`,
+    params: `?cursorId=${cursorId}`,
+  };
+
+  const response = await fetchHandler(fetchInfo);
+
+  return response;
+};
+
+export default asyncGetPostLikeList;

--- a/src/api/keyword/asyncGetPostLikeList.js
+++ b/src/api/keyword/asyncGetPostLikeList.js
@@ -1,0 +1,15 @@
+import fetchHandler from "..";
+import { BASE_URL } from "../../config/constants";
+
+const asyncGetPostLikeList = async (keywordId, cursorId) => {
+  const fetchInfo = {
+    url: `${BASE_URL}/posts/keywords/${keywordId}/postLike`,
+    params: `?cursorId=${cursorId}`,
+  };
+
+  const response = await fetchHandler(fetchInfo);
+
+  return response;
+};
+
+export default asyncGetPostLikeList;

--- a/src/api/post/asyncGetPosts.js
+++ b/src/api/post/asyncGetPosts.js
@@ -6,12 +6,15 @@ const asyncGetPosts = async (
   {
     keywordId,
     includedKeyword = POST_LISTS.DEFAULT_INCLUDED_KEYWORD,
+    excludedKeyword = POST_LISTS.DEFAULT_EXCLUDED_KEYWORD,
     limit = POST_LISTS.DEFAULT_LIMIT,
   }
 ) => {
+  const includedKeywordParams = includedKeyword.length === 0 ? "" : includedKeyword.join();
+  const excludedKeywordParams = excludedKeyword.length === 0 ? "" : excludedKeyword.join();
   const fetchInfo = {
     url: `${BASE_URL}/posts/${keywordId}`,
-    params: `?includedKeyword=${includedKeyword}&limit=${limit}&cursorId=${cursorId}`,
+    params: `?includedKeyword=${includedKeywordParams}&excludedKeyword=${excludedKeywordParams}&limit=${limit}&cursorId=${cursorId}`,
   };
 
   const response = await fetchHandler(fetchInfo);

--- a/src/components/Card/Chart/GroupPeriodPostCountCard.jsx
+++ b/src/components/Card/Chart/GroupPeriodPostCountCard.jsx
@@ -1,0 +1,82 @@
+import { useState } from "react";
+
+import asyncGetGroupCommentCountList from "../../../api/group/asyncGetGroupCommentCountList";
+import asyncGetGroupLikeCountList from "../../../api/group/asyncGetGroupLikeCountList";
+import asyncGetGroupPostCountList from "../../../api/group/asyncGetGroupPostCountList";
+import { GROUP_CHART_TYPE } from "../../../config/constants";
+import GroupLineChart from "../../Chart/GroupLineChart";
+import GroupPeriodPagination from "../../Pagination/GroupPeriodPagination";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import PropTypes from "prop-types";
+
+const GroupPeriodPostCountCard = ({ groupChartType, groupId, hasUserUid }) => {
+  const [cursorId, setCursorId] = useState("");
+
+  const hasGroupId = !!groupId;
+  let queryFunction;
+
+  switch (groupChartType) {
+    case GROUP_CHART_TYPE.POST:
+      queryFunction = asyncGetGroupPostCountList;
+      break;
+    case GROUP_CHART_TYPE.LIKE:
+      queryFunction = asyncGetGroupLikeCountList;
+      break;
+    case GROUP_CHART_TYPE.COMMENT:
+      queryFunction = asyncGetGroupCommentCountList;
+      break;
+  }
+
+  const {
+    data: groupPostCountData,
+    isError: isGroupPostCountDataError,
+    isPlaceholderData,
+  } = useQuery({
+    queryKey: ["groupPostCount", cursorId, groupId, groupChartType],
+    queryFn: () => queryFunction(cursorId, groupId),
+    placeholderData: keepPreviousData,
+    enabled: hasUserUid && hasGroupId,
+    staleTime: 5 * 1000,
+  });
+
+  const isError =
+    isGroupPostCountDataError || groupPostCountData?.message?.includes("Error occured");
+
+  if (isError) {
+    return (
+      <article className="flex-col-center w-full h-full border-2 rounded-md">
+        에러가 발생하였습니다. 잠시 후 다시 시도해주시기 바랍니다.
+      </article>
+    );
+  }
+
+  if (groupPostCountData === undefined) {
+    return null;
+  }
+
+  return (
+    <article
+      className={`flex flex-col gap-6 h-full p-10 border-2 rounded-md ${groupChartType === GROUP_CHART_TYPE.POST ? "w-full" : "w-1/2"}`}
+    >
+      <span className="flex-shrink-0 bg-green-100/20 px-10 py-5 rounded-[2px]">
+        {groupChartType}
+      </span>
+      <div className="flex-col-center h-full gap-5">
+        <GroupLineChart groupChartType={groupChartType} chartData={groupPostCountData} />
+        <GroupPeriodPagination
+          chartData={groupPostCountData}
+          setCursorId={setCursorId}
+          isPlaceholderData={isPlaceholderData}
+        />
+      </div>
+    </article>
+  );
+};
+
+export default GroupPeriodPostCountCard;
+
+GroupPeriodPostCountCard.propTypes = {
+  groupChartType: PropTypes.string.isRequired,
+  groupId: PropTypes.string.isRequired,
+  hasUserUid: PropTypes.bool.isRequired,
+};

--- a/src/components/Card/Chart/PeriodPostCommentCard.jsx
+++ b/src/components/Card/Chart/PeriodPostCommentCard.jsx
@@ -1,13 +1,13 @@
 import { useState } from "react";
 
-import asyncGetPostCountList from "../../../api/keyword/asyncGetPostCountList";
+import asyncGetPostCommentList from "../../../api/keyword/asyncGetPostCommentList";
 import { getCursorDate } from "../../../utils/date";
-import LineChart from "../../Chart/LineChart";
+import BarChart from "../../Chart/BarChart";
 import PeriodPagination from "../../Pagination/PeriodPagination";
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import PropTypes from "prop-types";
 
-const PeriodPostCountCard = ({ keywordId }) => {
+const PeriodPostCommentCard = ({ keywordId }) => {
   const [cursorId, setCursorId] = useState(() => getCursorDate());
 
   const {
@@ -15,9 +15,9 @@ const PeriodPostCountCard = ({ keywordId }) => {
     isPlaceholderData,
     isError,
   } = useQuery({
-    queryKey: ["postCount", keywordId, cursorId],
-    queryFn: () => asyncGetPostCountList(keywordId, cursorId),
-    select: (data) => ({ ...data, items: data.postCountList }),
+    queryKey: ["postComment", keywordId, cursorId],
+    queryFn: () => asyncGetPostCommentList(keywordId, cursorId),
+    select: (data) => ({ ...data, items: data.postCommentList }),
     placeholderData: keepPreviousData,
   });
 
@@ -27,17 +27,17 @@ const PeriodPostCountCard = ({ keywordId }) => {
 
   if (isError || chartData?.message?.includes("Error occured")) {
     return (
-      <div className="w-1/2 h-full min-h-300 p-10 border-2 rounded-md flex justify-center items-center">
-        주간 게시물 차트를 불러오는 데 실패했습니다.
+      <div className="w-1/2 h-full p-10 border-2 rounded-md flex justify-center items-center">
+        주간 댓글 수 차트를 불러오는 데 실패했습니다.
       </div>
     );
   }
 
   return (
-    <article className="flex flex-col gap-6 w-full h-full p-10 border-2 rounded-md">
-      <span className="flex-shrink-0 bg-green-100/20 px-10 py-5 rounded-[2px]">주간 게시물 수</span>
+    <article className="flex flex-col gap-6 w-1/2 h-full p-10 border-2 rounded-md">
+      <span className="flex-shrink-0 bg-green-100/20 px-10 py-5 rounded-[2px]">주간 댓글 수</span>
       <div className="flex-col-center">
-        <LineChart chartData={chartData} />
+        <BarChart chartData={chartData} />
         <PeriodPagination
           chartData={chartData}
           setCursorId={setCursorId}
@@ -48,8 +48,8 @@ const PeriodPostCountCard = ({ keywordId }) => {
   );
 };
 
-export default PeriodPostCountCard;
+export default PeriodPostCommentCard;
 
-PeriodPostCountCard.propTypes = {
+PeriodPostCommentCard.propTypes = {
   keywordId: PropTypes.string.isRequired,
 };

--- a/src/components/Card/Chart/PeriodPostLikeCard.jsx
+++ b/src/components/Card/Chart/PeriodPostLikeCard.jsx
@@ -1,13 +1,13 @@
 import { useState } from "react";
 
-import asyncGetPostCountList from "../../../api/keyword/asyncGetPostCountList";
+import asyncGetPostLikeList from "../../../api/keyword/asyncGetPostLikeList";
 import { getCursorDate } from "../../../utils/date";
 import LineChart from "../../Chart/LineChart";
 import PeriodPagination from "../../Pagination/PeriodPagination";
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import PropTypes from "prop-types";
 
-const PeriodPostCountCard = ({ keywordId }) => {
+const PeriodPostLikeCard = ({ keywordId }) => {
   const [cursorId, setCursorId] = useState(() => getCursorDate());
 
   const {
@@ -15,9 +15,9 @@ const PeriodPostCountCard = ({ keywordId }) => {
     isPlaceholderData,
     isError,
   } = useQuery({
-    queryKey: ["postCount", keywordId, cursorId],
-    queryFn: () => asyncGetPostCountList(keywordId, cursorId),
-    select: (data) => ({ ...data, items: data.postCountList }),
+    queryKey: ["postLike", keywordId, cursorId],
+    queryFn: () => asyncGetPostLikeList(keywordId, cursorId),
+    select: (data) => ({ ...data, items: data.postLikeList }),
     placeholderData: keepPreviousData,
   });
 
@@ -27,15 +27,15 @@ const PeriodPostCountCard = ({ keywordId }) => {
 
   if (isError || chartData?.message?.includes("Error occured")) {
     return (
-      <div className="w-1/2 h-full min-h-300 p-10 border-2 rounded-md flex justify-center items-center">
-        주간 게시물 차트를 불러오는 데 실패했습니다.
+      <div className="w-1/2 h-full p-10 border-2 rounded-md flex justify-center items-center">
+        주간 공감 수 차트를 불러오는 데 실패했습니다.
       </div>
     );
   }
 
   return (
-    <article className="flex flex-col gap-6 w-full h-full p-10 border-2 rounded-md">
-      <span className="flex-shrink-0 bg-green-100/20 px-10 py-5 rounded-[2px]">주간 게시물 수</span>
+    <article className="flex flex-col gap-6 w-1/2 h-full p-10 border-2 rounded-md">
+      <span className="flex-shrink-0 bg-green-100/20 px-10 py-5 rounded-[2px]">주간 공감 수</span>
       <div className="flex-col-center">
         <LineChart chartData={chartData} />
         <PeriodPagination
@@ -48,8 +48,8 @@ const PeriodPostCountCard = ({ keywordId }) => {
   );
 };
 
-export default PeriodPostCountCard;
+export default PeriodPostLikeCard;
 
-PeriodPostCountCard.propTypes = {
+PeriodPostLikeCard.propTypes = {
   keywordId: PropTypes.string.isRequired,
 };

--- a/src/components/Card/Chart/TodayPostCountCard.jsx
+++ b/src/components/Card/Chart/TodayPostCountCard.jsx
@@ -31,14 +31,14 @@ const TodayPostCountCard = ({ keywordId }) => {
     <article className="flex flex-col gap-40 w-[35%] h-full p-10 border-2 rounded-md flex-shrink-0">
       <span className="bg-green-100/20 px-10 py-5 rounded-[2px]">오늘의 게시물</span>
       <div className="flex flex-col gap-10 h-full">
-        <p className="flex justify-center">
+        <div className="flex justify-center">
           {isEqual && <EndashIcon className="size-90" />}
           {greaterThanYesterday && <UpwardArrowIcon className="size-90" />}
           {lessThanYesterday && <DownwardArrowIcon className="size-90" />}
           <p className="text-50 justify-center items-center pt-8">
             {!isEqual && chartData.diffPostCount}
           </p>
-        </p>
+        </div>
         <span className="flex-center text-120">{chartData.todayPostCount}</span>
       </div>
     </article>

--- a/src/components/Card/Chart/TodayPostCountCard.jsx
+++ b/src/components/Card/Chart/TodayPostCountCard.jsx
@@ -23,7 +23,7 @@ const TodayPostCountCard = ({ keywordId }) => {
     );
   }
 
-  const noDiff = Number(chartData?.diffPostCount) === 0;
+  const isEqual = Number(chartData?.diffPostCount) === 0;
   const greaterThanYesterday = Number(chartData.diffPostCount) > 0;
   const lessThanYesterday = Number(chartData.diffPostCount) < 0;
 
@@ -32,9 +32,12 @@ const TodayPostCountCard = ({ keywordId }) => {
       <span className="bg-green-100/20 px-10 py-5 rounded-[2px]">오늘의 게시물</span>
       <div className="flex flex-col gap-10 h-full">
         <p className="flex justify-center">
-          {noDiff && <EndashIcon className="size-90" />}
+          {isEqual && <EndashIcon className="size-90" />}
           {greaterThanYesterday && <UpwardArrowIcon className="size-90" />}
           {lessThanYesterday && <DownwardArrowIcon className="size-90" />}
+          <p className="text-50 justify-center items-center pt-8">
+            {!isEqual && chartData.diffPostCount}
+          </p>
         </p>
         <span className="flex-center text-120">{chartData.todayPostCount}</span>
       </div>

--- a/src/components/Card/Post/PostCard.jsx
+++ b/src/components/Card/Post/PostCard.jsx
@@ -29,11 +29,11 @@ const PostCard = ({
       <div className="flex justify-between items-center w-full">
         <div className="flex items-center gap-10 ">
           <span className="text-slate-500 text-14">
-            좋아요
+            공감
             <span className="text-slate-900"> {likeCount}</span>
           </span>
           <span className="text-slate-500 text-14">
-            댓글수
+            댓글
             <span className="text-slate-900"> {commentCount}</span>
           </span>
           <span className="text-slate-500 text-14">

--- a/src/components/Card/Post/PostCardList.jsx
+++ b/src/components/Card/Post/PostCardList.jsx
@@ -41,7 +41,7 @@ const PostCardList = ({ keywordId, filterList }) => {
       {isPending ? (
         <Loading width={100} height={100} text={""} />
       ) : postResponse?.pages[0]?.items?.length === 0 ? (
-        <p className="w-full h-full flex-center text-22">해당 키워드에 대한 블로그가 없습니다</p>
+        <p className="w-full h-full flex-center text-22">확인할 수 있는 게시물이 없어요</p>
       ) : (
         postResponse?.pages?.map((page) => {
           return page.items?.map((postInfo) => {

--- a/src/components/Card/Post/PostCardList.jsx
+++ b/src/components/Card/Post/PostCardList.jsx
@@ -70,7 +70,7 @@ export default PostCardList;
 PostCardList.propTypes = {
   keywordId: PropTypes.string.isRequired,
   filterList: PropTypes.shape({
-    includedKeyword: PropTypes.array.isRequired,
-    excludedKeyword: PropTypes.array.isRequired,
+    includedKeyword: PropTypes.arrayOf(PropTypes.string.isRequired),
+    excludedKeyword: PropTypes.arrayOf(PropTypes.string.isRequired),
   }),
 };

--- a/src/components/Card/Post/PostCardList.jsx
+++ b/src/components/Card/Post/PostCardList.jsx
@@ -8,16 +8,17 @@ import Loading from "../../UI/Loading";
 import PostCard from "./PostCard";
 import PropTypes from "prop-types";
 
-const PostCardList = ({ keywordId }) => {
+const PostCardList = ({ keywordId, subKeywordList }) => {
   const observeRef = useRef(null);
   const observeRootRef = useRef(null);
 
   const infiniteDataArgument = {
-    queryKey: ["posts", keywordId],
+    queryKey: ["posts", keywordId, subKeywordList],
     queryFn: asyncGetPosts,
     options: {
       keywordId,
-      includedKeyword: "",
+      includedKeyword: subKeywordList.includedKeyword,
+      excludedKeyword: subKeywordList.excludedKeyword,
       limit: 5,
     },
     initialPageParam: "",
@@ -68,4 +69,8 @@ export default PostCardList;
 
 PostCardList.propTypes = {
   keywordId: PropTypes.string.isRequired,
+  subKeywordList: PropTypes.shape({
+    includedKeyword: PropTypes.array.isRequired,
+    excludedKeyword: PropTypes.array.isRequired,
+  }),
 };

--- a/src/components/Card/Post/PostCardList.jsx
+++ b/src/components/Card/Post/PostCardList.jsx
@@ -8,17 +8,17 @@ import Loading from "../../UI/Loading";
 import PostCard from "./PostCard";
 import PropTypes from "prop-types";
 
-const PostCardList = ({ keywordId, subKeywordList }) => {
+const PostCardList = ({ keywordId, filterList }) => {
   const observeRef = useRef(null);
   const observeRootRef = useRef(null);
 
   const infiniteDataArgument = {
-    queryKey: ["posts", keywordId, subKeywordList],
+    queryKey: ["posts", keywordId, filterList],
     queryFn: asyncGetPosts,
     options: {
       keywordId,
-      includedKeyword: subKeywordList.includedKeyword,
-      excludedKeyword: subKeywordList.excludedKeyword,
+      includedKeyword: filterList.includedKeyword,
+      excludedKeyword: filterList.excludedKeyword,
       limit: 5,
     },
     initialPageParam: "",
@@ -69,7 +69,7 @@ export default PostCardList;
 
 PostCardList.propTypes = {
   keywordId: PropTypes.string.isRequired,
-  subKeywordList: PropTypes.shape({
+  filterList: PropTypes.shape({
     includedKeyword: PropTypes.array.isRequired,
     excludedKeyword: PropTypes.array.isRequired,
   }),

--- a/src/components/Card/Post/PostListFilter.jsx
+++ b/src/components/Card/Post/PostListFilter.jsx
@@ -7,7 +7,7 @@ import Label from "../../UI/Label";
 import PropTypes from "prop-types";
 
 const PostListFilter = ({ filterList, setFilterList }) => {
-  const [subKeywordListAdded, setSubKeywordListAdded] = useState({
+  const [tempFilterList, setTempFilterList] = useState({
     includedKeyword: filterList.includedKeyword,
     excludedKeyword: filterList.excludedKeyword,
   });
@@ -19,116 +19,131 @@ const PostListFilter = ({ filterList, setFilterList }) => {
     includedKeyword: "",
     excludedKeyword: "",
   });
-  const handleSubKeywordInputChange = (e, subKeywordType) => {
-    setInputValue((prev) => ({ ...prev, [subKeywordType]: e.target.value }));
+  const handleFilterInputChange = (e, filterType) => {
+    setInputValue((prev) => ({ ...prev, [filterType]: e.target.value }));
     return;
   };
-  const handleSubKeywordEnterSubmit = (e, subKeywordType) => {
+  const handleCreateTempFilterSubmit = (e, filterType) => {
     e.preventDefault();
-    if (inputValue[subKeywordType]?.trim() === "") {
+    if (inputValue[filterType]?.trim() === "") {
       return;
     }
-    const hasSubKeyword = Object.values(subKeywordListAdded).some((subKeyword) =>
-      subKeyword.includes(inputValue[subKeywordType])
+    const hasFilter = Object.values(tempFilterList).some((filter) =>
+      filter.includes(inputValue[filterType])
     );
-    if (hasSubKeyword) {
+    if (hasFilter) {
       setErrorMessage((prev) => ({
         ...prev,
-        [subKeywordType]: ERROR_MESSAGE.KEYWORD_DUPLICATED_INPUT_VALUE,
+        [filterType]: ERROR_MESSAGE.KEYWORD_DUPLICATED_INPUT_VALUE,
       }));
       return;
     }
 
-    setSubKeywordListAdded((prev) => ({
+    setTempFilterList((prev) => ({
       ...prev,
-      [subKeywordType]: [...prev[subKeywordType], inputValue[subKeywordType]],
+      [filterType]: [...prev[filterType], inputValue[filterType]],
     }));
-    setInputValue((prev) => ({ ...prev, [subKeywordType]: "" }));
-    setErrorMessage((prev) => ({ ...prev, [subKeywordType]: "" }));
+    setInputValue((prev) => ({ ...prev, [filterType]: "" }));
+    setErrorMessage((prev) => ({ ...prev, [filterType]: "" }));
     return;
   };
-  const handleSubKeywordChipRemoveButtonClick = (subKeywordType, subKeywordNameForRemove) => {
-    setSubKeywordListAdded((prev) => ({
+  const handleFilterChipRemoveButtonClick = (filterType, filterForRemove) => {
+    setTempFilterList((prev) => ({
       ...prev,
-      [subKeywordType]: prev[subKeywordType].filter(
-        (subKeywordName) => subKeywordName !== subKeywordNameForRemove
-      ),
+      [filterType]: prev[filterType].filter((filter) => filter !== filterForRemove),
     }));
     return;
   };
   const handleFilterApplyButtonClick = () => {
-    const isEqualQueryResult =
-      Object.values(filterList).join() === Object.values(subKeywordListAdded).join();
-    if (isEqualQueryResult) {
-      alert("현재 검색 결과와 동일해요");
+    const filterListSet = new Set(Object.values(filterList).flat());
+    const tempFilterListSet = new Set(Object.values(tempFilterList).flat());
+    const hasFilter = Array.from(tempFilterListSet).some((filter) => filterListSet.has(filter));
+
+    if (hasFilter) {
       return;
     }
-    setFilterList(subKeywordListAdded);
+    setFilterList(tempFilterList);
     return;
   };
   return (
-    <div className="relative w-full h-210">
-      <div className="absolute top-0 right-20 w-8/12 h-40 my-15 px-15 border-2 font-semibold">
-        <form onSubmit={(e) => handleSubKeywordEnterSubmit(e, "includedKeyword")}>
-          <Label
-            htmlFor="includedKeyword"
-            styles="w-100 text-15 text-slate-700 font-semibold flex-shrink-0 hover:text-emerald-900/80"
+    <div className="flex flex-col gap-10 w-full px-20 py-10">
+      <div className="flex flex-col gap-5">
+        <div className="flex items-center gap-15 w-full">
+          <form
+            className="w-400 h-40 px-20 flex items-center gap-5 flex-shrink-0 border-2 rounded-md"
+            onSubmit={(e) => handleCreateTempFilterSubmit(e, "includedKeyword")}
           >
-            포함
-          </Label>
-          {subKeywordListAdded?.includedKeyword?.map((subKeyword) => {
-            return (
-              <KeywordChip
-                key={subKeyword}
-                keywordName={subKeyword}
-                hasCloseButton={true}
-                onClick={() => handleSubKeywordChipRemoveButtonClick("includedKeyword", subKeyword)}
-              />
-            );
-          })}
-          <input
-            type="text"
-            id="includedKeyword"
-            value={inputValue.includedKeyword}
-            onChange={(e) => handleSubKeywordInputChange(e, "includedKeyword")}
-            className="w-6/12 h-35 px-15 font-semibold outline-none"
-            placeholder="어떤 키워드를 포함할까요?"
-          />
-        </form>
-        <p className="text-15 text-red-400 h-18 font-semibold">{errorMessage.includedKeyword}</p>
+            <Label
+              htmlFor="includedKeyword"
+              styles="text-15 text-slate-700 font-semibold flex-shrink-0 hover:text-emerald-900/80"
+            >
+              포함
+            </Label>
+            <input
+              type="text"
+              id="includedKeyword"
+              value={inputValue.includedKeyword}
+              onChange={(e) => handleFilterInputChange(e, "includedKeyword")}
+              className="w-full flex-grow-1 h-full px-10 font-semibold outline-none"
+              placeholder="포함할 키워드"
+            />
+          </form>
+          <div className="flex items-center w-full h-full">
+            {tempFilterList?.includedKeyword?.map((subKeyword) => {
+              return (
+                <KeywordChip
+                  key={subKeyword}
+                  keywordName={subKeyword}
+                  hasCloseButton={true}
+                  onClick={() => handleFilterChipRemoveButtonClick("includedKeyword", subKeyword)}
+                  styles="px-10 py-5 m-5 border-solid border-2 rounded-xl bg-green-100 border-green-200"
+                />
+              );
+            })}
+          </div>
+        </div>
+        <p className="text-14 text-red-400 font-semibold">{errorMessage.includedKeyword}</p>
       </div>
-      <div className="absolute bottom-30 right-20 w-8/12 h-40 my-15 px-15 border-2 font-semibold">
-        <form onSubmit={(e) => handleSubKeywordEnterSubmit(e, "includedKeyword")}>
-          <Label
-            htmlFor="excludedKeyword"
-            styles="w-100 text-15 text-slate-700 font-semibold flex-shrink-0 hover:text-emerald-900/80"
+      <div className="flex flex-col gap-5">
+        <div className="flex items-center gap-15 w-full">
+          <form
+            className="w-400 h-40 px-20 flex items-center gap-5 flex-shrink-0 border-2 rounded-md"
+            onSubmit={(e) => handleCreateTempFilterSubmit(e, "excludedKeyword")}
           >
-            제외
-          </Label>
-          {subKeywordListAdded?.excludedKeyword?.map((subKeyword) => {
-            return (
-              <KeywordChip
-                key={subKeyword}
-                keywordName={subKeyword}
-                hasCloseButton={true}
-                onClick={() => handleSubKeywordChipRemoveButtonClick("excludedKeyword", subKeyword)}
-              />
-            );
-          })}
-          <input
-            type="text"
-            id="excludedKeyword"
-            value={inputValue.excludedKeyword}
-            onChange={(e) => handleSubKeywordInputChange(e, "excludedKeyword")}
-            className="w-6/12 h-35 px-15 font-semibold outline-none"
-            placeholder="어떤 키워드를 제외할까요?"
-          />
-        </form>
-        <p className="text-15 text-red-400 h-18 font-semibold">{errorMessage.excludedKeyword}</p>
+            <Label
+              htmlFor="excludedKeyword"
+              styles="text-15 text-slate-700 font-semibold flex-shrink-0 hover:text-emerald-900/80"
+            >
+              제외
+            </Label>
+            <input
+              type="text"
+              id="excludedKeyword"
+              value={inputValue.excludedKeyword}
+              onChange={(e) => handleFilterInputChange(e, "excludedKeyword")}
+              className="w-full flex-grow-1 h-full px-10 font-semibold outline-none"
+              placeholder="제외할 키워드"
+            />
+          </form>
+          <div className="flex items-center w-full h-full">
+            {tempFilterList?.excludedKeyword?.map((subKeyword) => {
+              return (
+                <KeywordChip
+                  key={subKeyword}
+                  keywordName={subKeyword}
+                  hasCloseButton={true}
+                  onClick={() => handleFilterChipRemoveButtonClick("excludedKeyword", subKeyword)}
+                  styles="px-10 py-3 m-5 border-solid border-2 rounded-xl bg-red-100 border-red-200"
+                />
+              );
+            })}
+          </div>
+        </div>
+        <p className="text-14 text-red-400 font-semibold">{errorMessage.excludedKeyword}</p>
       </div>
       <Button
         onClick={handleFilterApplyButtonClick}
-        styles="absolute bottom-0 right-20 px-50 py-5 rounded-[5px] font-medium text-gray-900/80 border-t-2 border-b-2 border-slate-200/80 font-semibold hover:bg-emerald-100/10 hover:border-emerald-900/20"
+        styles="w-200 right-20 px-50 py-5 rounded-[5px] font-medium text-gray-900/80 border-2 border-slate-200/80 font-semibold hover:bg-emerald-100/10 hover:border-emerald-900/20"
       >
         필터 적용
       </Button>

--- a/src/components/Card/Post/PostListFilter.jsx
+++ b/src/components/Card/Post/PostListFilter.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { ERROR_MESSAGE } from "../../../config/constants";
 import KeywordChip from "../../Chip/KeywordChip";
@@ -20,6 +20,13 @@ const PostListFilter = ({ filterList, setFilterList }) => {
     excludedKeyword: "",
   });
 
+  useEffect(() => {
+    setTempFilterList(() => ({
+      includedKeyword: filterList.includedKeyword,
+      excludedKeyword: filterList.excludedKeyword,
+    }));
+  }, [filterList.includedKeyword, filterList.excludedKeyword]);
+
   const handleFilterInputChange = (e, filterType) => {
     setInputValue((prev) => ({ ...prev, [filterType]: e.target.value }));
     return;
@@ -27,12 +34,13 @@ const PostListFilter = ({ filterList, setFilterList }) => {
 
   const handleCreateTempFilterSubmit = (e, filterType) => {
     e.preventDefault();
+    const trimmedInputValue = inputValue[filterType].trim();
 
-    if (inputValue[filterType]?.trim() === "") {
+    if (trimmedInputValue === "") {
       return;
     }
     const hasFilter = Object.values(tempFilterList).some((filter) =>
-      filter.includes(inputValue[filterType])
+      filter.includes(trimmedInputValue)
     );
 
     if (hasFilter) {
@@ -45,14 +53,14 @@ const PostListFilter = ({ filterList, setFilterList }) => {
 
     setTempFilterList((prev) => ({
       ...prev,
-      [filterType]: [...prev[filterType], inputValue[filterType]],
+      [filterType]: [...prev[filterType], trimmedInputValue],
     }));
     setInputValue((prev) => ({ ...prev, [filterType]: "" }));
     setErrorMessage((prev) => ({ ...prev, [filterType]: "" }));
     return;
   };
 
-  const handleFilterChipRemoveButtonClick = (filterType, filterForRemove) => {
+  const handleRemoveFilterChipClick = (filterType, filterForRemove) => {
     setTempFilterList((prev) => ({
       ...prev,
       [filterType]: prev[filterType].filter((filter) => filter !== filterForRemove),
@@ -103,7 +111,7 @@ const PostListFilter = ({ filterList, setFilterList }) => {
                   key={subKeyword}
                   keywordName={subKeyword}
                   hasCloseButton={true}
-                  onClick={() => handleFilterChipRemoveButtonClick("includedKeyword", subKeyword)}
+                  onClick={() => handleRemoveFilterChipClick("includedKeyword", subKeyword)}
                   styles="px-10 py-5 m-5 border-solid border-2 rounded-xl bg-green-100 border-green-200"
                 />
               );
@@ -140,7 +148,7 @@ const PostListFilter = ({ filterList, setFilterList }) => {
                   key={subKeyword}
                   keywordName={subKeyword}
                   hasCloseButton={true}
-                  onClick={() => handleFilterChipRemoveButtonClick("excludedKeyword", subKeyword)}
+                  onClick={() => handleRemoveFilterChipClick("excludedKeyword", subKeyword)}
                   styles="px-10 py-3 m-5 border-solid border-2 rounded-xl bg-red-100 border-red-200"
                 />
               );

--- a/src/components/Card/Post/PostListFilter.jsx
+++ b/src/components/Card/Post/PostListFilter.jsx
@@ -60,7 +60,7 @@ const PostListFilter = ({ filterList, setFilterList }) => {
     return;
   };
 
-  const handleRemoveFilterChipClick = (filterType, filterForRemove) => {
+  const handleFilterChipRemoveButtonClick = (filterType, filterForRemove) => {
     setTempFilterList((prev) => ({
       ...prev,
       [filterType]: prev[filterType].filter((filter) => filter !== filterForRemove),
@@ -111,7 +111,7 @@ const PostListFilter = ({ filterList, setFilterList }) => {
                   key={subKeyword}
                   keywordName={subKeyword}
                   hasCloseButton={true}
-                  onClick={() => handleRemoveFilterChipClick("includedKeyword", subKeyword)}
+                  onClick={() => handleFilterChipRemoveButtonClick("includedKeyword", subKeyword)}
                   styles="px-10 py-5 m-5 border-solid border-2 rounded-xl bg-green-100 border-green-200"
                 />
               );
@@ -148,7 +148,7 @@ const PostListFilter = ({ filterList, setFilterList }) => {
                   key={subKeyword}
                   keywordName={subKeyword}
                   hasCloseButton={true}
-                  onClick={() => handleRemoveFilterChipClick("excludedKeyword", subKeyword)}
+                  onClick={() => handleFilterChipRemoveButtonClick("excludedKeyword", subKeyword)}
                   styles="px-10 py-3 m-5 border-solid border-2 rounded-xl bg-red-100 border-red-200"
                 />
               );

--- a/src/components/Card/Post/PostListFilter.jsx
+++ b/src/components/Card/Post/PostListFilter.jsx
@@ -1,0 +1,137 @@
+import { useState } from "react";
+
+import { ERROR_MESSAGE } from "../../../config/constants";
+import KeywordChip from "../../Chip/KeywordChip";
+import Button from "../../UI/Button";
+import Label from "../../UI/Label";
+import PropTypes from "prop-types";
+
+const PostListFilter = ({ subKeywordList, setSubKeywordList }) => {
+  const [subKeywordListAdded, setSubKeywordListAdded] = useState({
+    includedKeyword: subKeywordList.includedKeyword,
+    excludedKeyword: subKeywordList.excludedKeyword,
+  });
+  const [inputValue, setInputValue] = useState({
+    includedKeyword: "",
+    excludedKeyword: "",
+  });
+  const [errorMessage, setErrorMessage] = useState({
+    includedKeyword: "",
+    excludedKeyword: "",
+  });
+  const handleSubKeywordInputChange = (e, subKeywordType) => {
+    setInputValue((prev) => ({ ...prev, [subKeywordType]: e.target.value }));
+    return;
+  };
+  const handleSubKeywordEnterSubmit = (e, subKeywordType) => {
+    e.preventDefault();
+    if (inputValue[subKeywordType]?.trim() === "") {
+      return;
+    }
+    const hasSubKeyword = Object.values(subKeywordListAdded).some((subKeyword) =>
+      subKeyword.includes(inputValue[subKeywordType])
+    );
+    if (hasSubKeyword) {
+      setErrorMessage((prev) => ({
+        ...prev,
+        [subKeywordType]: ERROR_MESSAGE.KEYWORD_DUPLICATED_INPUT_VALUE,
+      }));
+      return;
+    }
+
+    setSubKeywordListAdded((prev) => ({
+      ...prev,
+      [subKeywordType]: [...prev[subKeywordType], inputValue[subKeywordType]],
+    }));
+    setInputValue((prev) => ({ ...prev, [subKeywordType]: "" }));
+    setErrorMessage((prev) => ({ ...prev, [subKeywordType]: "" }));
+    return;
+  };
+  const handleSubKeywordChipRemoveButtonClick = (subKeywordType, subKeywordNameForRemove) => {
+    setSubKeywordListAdded((prev) => ({
+      ...prev,
+      [subKeywordType]: prev[subKeywordType].filter(
+        (subKeywordName) => subKeywordName !== subKeywordNameForRemove
+      ),
+    }));
+    return;
+  };
+  const handleFilterApplyButtonClick = () => {
+    const isEqualQueryResult =
+      Object.values(subKeywordList).join() === Object.values(subKeywordListAdded).join();
+    if (isEqualQueryResult) {
+      alert("현재 검색 결과와 동일해요");
+      return;
+    }
+    setSubKeywordList(subKeywordListAdded);
+    return;
+  };
+  return (
+    <div className="relative w-full h-210">
+      <div className="absolute top-0 right-20 w-8/12 h-40 my-15 px-15 border-2 font-semibold">
+        <form onSubmit={(e) => handleSubKeywordEnterSubmit(e, "includedKeyword")}>
+          <Label htmlFor="includedKeyword"></Label>
+          {subKeywordListAdded?.includedKeyword?.map((subKeyword) => {
+            return (
+              <KeywordChip
+                key={subKeyword}
+                keywordName={subKeyword}
+                hasCloseButton={true}
+                onClick={() => handleSubKeywordChipRemoveButtonClick("includedKeyword", subKeyword)}
+              />
+            );
+          })}
+          <input
+            type="text"
+            id="includedKeyword"
+            value={inputValue.includedKeyword}
+            onChange={(e) => handleSubKeywordInputChange(e, "includedKeyword")}
+            className="w-6/12 h-35 px-15 font-semibold outline-none"
+            placeholder="어떤 키워드를 포함할까요?"
+          />
+        </form>
+        <p className="text-15 text-red-400 h-18 font-semibold">{errorMessage.includedKeyword}</p>
+      </div>
+      <div className="absolute bottom-30 right-20 w-8/12 h-40 my-15 px-15 border-2 font-semibold">
+        <form onSubmit={(e) => handleSubKeywordEnterSubmit(e, "includedKeyword")}>
+          <Label htmlFor="excludedKeyword"></Label>
+          {subKeywordListAdded?.excludedKeyword?.map((subKeyword) => {
+            return (
+              <KeywordChip
+                key={subKeyword}
+                keywordName={subKeyword}
+                hasCloseButton={true}
+                onClick={() => handleSubKeywordChipRemoveButtonClick("excludedKeyword", subKeyword)}
+              />
+            );
+          })}
+          <input
+            type="text"
+            id="excludedKeyword"
+            value={inputValue.excludedKeyword}
+            onChange={(e) => handleSubKeywordInputChange(e, "excludedKeyword")}
+            className="w-6/12 h-35 px-15 font-semibold outline-none"
+            placeholder="어떤 키워드를 제외할까요?"
+          />
+        </form>
+        <p className="text-15 text-red-400 h-18 font-semibold">{errorMessage.excludedKeyword}</p>
+      </div>
+      <Button
+        onClick={handleFilterApplyButtonClick}
+        styles="absolute bottom-0 right-20 px-50 py-5 rounded-[5px] font-medium text-gray-900/80 border-t-2 border-b-2 border-slate-200/80 font-semibold hover:bg-emerald-100/10 hover:border-emerald-900/20"
+      >
+        필터 적용
+      </Button>
+    </div>
+  );
+};
+
+export default PostListFilter;
+
+PostListFilter.propTypes = {
+  subKeywordList: PropTypes.shape({
+    includedKeyword: PropTypes.array.isRequired,
+    excludedKeyword: PropTypes.array.isRequired,
+  }),
+  setSubKeywordList: PropTypes.func.isRequired,
+};

--- a/src/components/Card/Post/PostListFilter.jsx
+++ b/src/components/Card/Post/PostListFilter.jsx
@@ -19,18 +19,22 @@ const PostListFilter = ({ filterList, setFilterList }) => {
     includedKeyword: "",
     excludedKeyword: "",
   });
+
   const handleFilterInputChange = (e, filterType) => {
     setInputValue((prev) => ({ ...prev, [filterType]: e.target.value }));
     return;
   };
+
   const handleCreateTempFilterSubmit = (e, filterType) => {
     e.preventDefault();
+
     if (inputValue[filterType]?.trim() === "") {
       return;
     }
     const hasFilter = Object.values(tempFilterList).some((filter) =>
       filter.includes(inputValue[filterType])
     );
+
     if (hasFilter) {
       setErrorMessage((prev) => ({
         ...prev,
@@ -47,6 +51,7 @@ const PostListFilter = ({ filterList, setFilterList }) => {
     setErrorMessage((prev) => ({ ...prev, [filterType]: "" }));
     return;
   };
+
   const handleFilterChipRemoveButtonClick = (filterType, filterForRemove) => {
     setTempFilterList((prev) => ({
       ...prev,
@@ -54,6 +59,7 @@ const PostListFilter = ({ filterList, setFilterList }) => {
     }));
     return;
   };
+
   const handleFilterApplyButtonClick = () => {
     const filterListSet = new Set(Object.values(filterList).flat());
     const tempFilterListSet = new Set(Object.values(tempFilterList).flat());
@@ -62,9 +68,11 @@ const PostListFilter = ({ filterList, setFilterList }) => {
     if (hasFilter) {
       return;
     }
+
     setFilterList(tempFilterList);
     return;
   };
+
   return (
     <div className="flex flex-col gap-10 w-full px-20 py-10">
       <div className="flex flex-col gap-5">

--- a/src/components/Card/Post/PostListFilter.jsx
+++ b/src/components/Card/Post/PostListFilter.jsx
@@ -61,11 +61,11 @@ const PostListFilter = ({ filterList, setFilterList }) => {
   };
 
   const handleFilterApplyButtonClick = () => {
-    const filterListSet = new Set(Object.values(filterList).flat());
-    const tempFilterListSet = new Set(Object.values(tempFilterList).flat());
-    const hasFilter = Array.from(tempFilterListSet).some((filter) => filterListSet.has(filter));
+    const filters = Object.values(filterList).flat().sort();
+    const tempFilters = Object.values(tempFilterList).flat().sort();
+    const isEqualFilter = tempFilters.every((filter, index) => filter === filters[index]);
 
-    if (hasFilter) {
+    if (isEqualFilter) {
       return;
     }
 

--- a/src/components/Card/Post/PostListFilter.jsx
+++ b/src/components/Card/Post/PostListFilter.jsx
@@ -6,10 +6,10 @@ import Button from "../../UI/Button";
 import Label from "../../UI/Label";
 import PropTypes from "prop-types";
 
-const PostListFilter = ({ subKeywordList, setSubKeywordList }) => {
+const PostListFilter = ({ filterList, setFilterList }) => {
   const [subKeywordListAdded, setSubKeywordListAdded] = useState({
-    includedKeyword: subKeywordList.includedKeyword,
-    excludedKeyword: subKeywordList.excludedKeyword,
+    includedKeyword: filterList.includedKeyword,
+    excludedKeyword: filterList.excludedKeyword,
   });
   const [inputValue, setInputValue] = useState({
     includedKeyword: "",
@@ -58,19 +58,24 @@ const PostListFilter = ({ subKeywordList, setSubKeywordList }) => {
   };
   const handleFilterApplyButtonClick = () => {
     const isEqualQueryResult =
-      Object.values(subKeywordList).join() === Object.values(subKeywordListAdded).join();
+      Object.values(filterList).join() === Object.values(subKeywordListAdded).join();
     if (isEqualQueryResult) {
       alert("현재 검색 결과와 동일해요");
       return;
     }
-    setSubKeywordList(subKeywordListAdded);
+    setFilterList(subKeywordListAdded);
     return;
   };
   return (
     <div className="relative w-full h-210">
       <div className="absolute top-0 right-20 w-8/12 h-40 my-15 px-15 border-2 font-semibold">
         <form onSubmit={(e) => handleSubKeywordEnterSubmit(e, "includedKeyword")}>
-          <Label htmlFor="includedKeyword"></Label>
+          <Label
+            htmlFor="includedKeyword"
+            styles="w-100 text-15 text-slate-700 font-semibold flex-shrink-0 hover:text-emerald-900/80"
+          >
+            포함
+          </Label>
           {subKeywordListAdded?.includedKeyword?.map((subKeyword) => {
             return (
               <KeywordChip
@@ -94,7 +99,12 @@ const PostListFilter = ({ subKeywordList, setSubKeywordList }) => {
       </div>
       <div className="absolute bottom-30 right-20 w-8/12 h-40 my-15 px-15 border-2 font-semibold">
         <form onSubmit={(e) => handleSubKeywordEnterSubmit(e, "includedKeyword")}>
-          <Label htmlFor="excludedKeyword"></Label>
+          <Label
+            htmlFor="excludedKeyword"
+            styles="w-100 text-15 text-slate-700 font-semibold flex-shrink-0 hover:text-emerald-900/80"
+          >
+            제외
+          </Label>
           {subKeywordListAdded?.excludedKeyword?.map((subKeyword) => {
             return (
               <KeywordChip
@@ -129,9 +139,9 @@ const PostListFilter = ({ subKeywordList, setSubKeywordList }) => {
 export default PostListFilter;
 
 PostListFilter.propTypes = {
-  subKeywordList: PropTypes.shape({
+  filterList: PropTypes.shape({
     includedKeyword: PropTypes.array.isRequired,
     excludedKeyword: PropTypes.array.isRequired,
   }),
-  setSubKeywordList: PropTypes.func.isRequired,
+  setFilterList: PropTypes.func.isRequired,
 };

--- a/src/components/Chart/BarChart.jsx
+++ b/src/components/Chart/BarChart.jsx
@@ -1,20 +1,20 @@
-import { Line } from "react-chartjs-2";
+import { Bar } from "react-chartjs-2";
 
 import { CHART_COLOR } from "../../config/constants";
 import { changeMonthDateFormat } from "../../utils/date";
 import {
+  BarElement,
   CategoryScale,
   Chart as ChartJS,
-  LineElement,
   LinearScale,
   PointElement,
   Tooltip,
 } from "chart.js";
 import PropTypes from "prop-types";
 
-ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip);
+ChartJS.register(CategoryScale, LinearScale, PointElement, BarElement, Tooltip);
 
-const LineChart = ({ chartData }) => {
+const BarChart = ({ chartData }) => {
   const data = {
     labels: chartData.dates.map((date) => changeMonthDateFormat(date)),
     datasets: [
@@ -36,12 +36,12 @@ const LineChart = ({ chartData }) => {
     },
   };
 
-  return <Line options={options} data={data} />;
+  return <Bar options={options} data={data} />;
 };
 
-export default LineChart;
+export default BarChart;
 
-LineChart.propTypes = {
+BarChart.propTypes = {
   chartData: PropTypes.shape({
     keywordId: PropTypes.string,
     keyword: PropTypes.string,

--- a/src/components/Chart/GroupLineChart.jsx
+++ b/src/components/Chart/GroupLineChart.jsx
@@ -1,0 +1,98 @@
+import { Line } from "react-chartjs-2";
+
+import { CHART_COLOR, GROUP_CHART_TYPE } from "../../config/constants";
+import { changeMonthDateFormat } from "../../utils/date";
+import {
+  CategoryScale,
+  Chart as ChartJS,
+  LineElement,
+  LinearScale,
+  PointElement,
+  Tooltip,
+  plugins,
+} from "chart.js";
+import PropTypes from "prop-types";
+
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip, plugins);
+
+const GroupLineChart = ({ groupChartType, chartData }) => {
+  const data = {
+    labels: chartData?.items[0]?.dates?.map((date) => changeMonthDateFormat(date)),
+    datasets: chartData?.items?.map((keyword, index) => {
+      let data;
+
+      if (groupChartType === GROUP_CHART_TYPE.POST) {
+        data = keyword.postCountList;
+      } else if (groupChartType === GROUP_CHART_TYPE.LIKE) {
+        data = keyword.likeCountList;
+      } else if (groupChartType === GROUP_CHART_TYPE.COMMENT) {
+        data = keyword.commentCountList;
+      }
+
+      return {
+        label: keyword.name,
+        data,
+        borderColor: CHART_COLOR[index % 5],
+        backgroundColor: CHART_COLOR[index % 5],
+      };
+    }),
+  };
+
+  const options = {
+    responsive: true,
+    scales: {
+      y: {
+        beginAtZero: true,
+      },
+    },
+    maintainAspectRatio: true,
+    aspectRatio: 2.6,
+
+    plugins: {
+      legend: {
+        display: true,
+        position: "top",
+        align: "center",
+        labels: {
+          padding: 11,
+          boxWidth: 11,
+          color: "#000000",
+          usePointStyle: false,
+          pointStyle: "circle",
+          font: {
+            family: "Pretendard",
+            size: 12,
+            lineHeight: 2,
+            weight: "normal",
+          },
+        },
+      },
+    },
+  };
+
+  return <Line options={options} data={data} />;
+};
+
+export default GroupLineChart;
+
+GroupLineChart.propTypes = {
+  groupChartType: PropTypes.string.isRequired,
+  chartData: PropTypes.shape({
+    groupId: PropTypes.string.isRequired,
+    keywordIdList: PropTypes.arrayOf(PropTypes.string).isRequired,
+    items: PropTypes.arrayOf(
+      PropTypes.shape({
+        name: PropTypes.string,
+        postCountList: PropTypes.arrayOf(PropTypes.number),
+        likeCountList: PropTypes.arrayOf(PropTypes.number),
+        commentCountList: PropTypes.arrayOf(PropTypes.number),
+        dates: PropTypes.arrayOf(PropTypes.string),
+      })
+    ).isRequired,
+    hasPrevious: PropTypes.bool.isRequired,
+    hasNext: PropTypes.bool.isRequired,
+    cursorId: PropTypes.string.isRequired,
+    previousCursorId: PropTypes.string.isRequired,
+    nextCursorId: PropTypes.string.isRequired,
+  }).isRequired,
+};

--- a/src/components/Chip/KeywordChip.jsx
+++ b/src/components/Chip/KeywordChip.jsx
@@ -7,8 +7,8 @@ const KeywordChip = ({ keywordName, styles, hasCloseButton, onClick }) => {
     <span className={styles}>
       {keywordName}
       {hasCloseButton && (
-        <Button styles="right-17" onClick={onClick}>
-          <CloseIcon className="size-25" />
+        <Button styles="align-middle" onClick={onClick}>
+          <CloseIcon className="size-20 ml-5" />
         </Button>
       )}
     </span>

--- a/src/components/Chip/KeywordChip.jsx
+++ b/src/components/Chip/KeywordChip.jsx
@@ -1,7 +1,18 @@
+import CloseIcon from "../Icon/CloseIcon";
+import Button from "../UI/Button";
 import PropTypes from "prop-types";
 
-const KeywordChip = ({ keywordName, styles }) => {
-  return <span className={styles}>{keywordName}</span>;
+const KeywordChip = ({ keywordName, styles, hasCloseButton, onClick }) => {
+  return (
+    <span className={styles}>
+      {keywordName}
+      {hasCloseButton && (
+        <Button styles="right-17" onClick={onClick}>
+          <CloseIcon className="size-25" />
+        </Button>
+      )}
+    </span>
+  );
 };
 
 export default KeywordChip;
@@ -9,4 +20,6 @@ export default KeywordChip;
 KeywordChip.propTypes = {
   keywordName: PropTypes.string.isRequired,
   styles: PropTypes.string.isRequired,
+  hasCloseButton: PropTypes.bool,
+  onClick: PropTypes.func,
 };

--- a/src/components/Modal/ErrorModal.jsx
+++ b/src/components/Modal/ErrorModal.jsx
@@ -18,7 +18,7 @@ const ErrorModal = ({ errorMessage }) => {
       <ModalBackground isClear={false} modalType={MODAL_TYPE.ERROR}>
         <ModalFrame isClear={false} hasCloseButton={false} modalType={MODAL_TYPE.ERROR}>
           <main className="flex flex-col gap-10 items-center">
-            <h1 className="text-16 text-red-400">{errorMessage} 😅</h1>
+            <h1 className="text-16 text-red-400">{errorMessage}</h1>
             <Button
               type="button"
               styles="flex-center px-14 py-8 font-medium border-2 border-purple-200 bg-purple-400/80 rounded-[15px] text-white text-18 hover:bg-purple-500/80"

--- a/src/components/Pagination/GroupPeriodPagination.jsx
+++ b/src/components/Pagination/GroupPeriodPagination.jsx
@@ -1,0 +1,61 @@
+import { changeDateWithDotFormat } from "../../utils/date";
+import LeftCarouselIcon from "../Icon/LeftCarouselIcon";
+import RightCarouselIcon from "../Icon/RightCarouselIcon";
+import Button from "../UI/Button";
+import PropTypes from "prop-types";
+
+const GroupPeriodPagination = ({ chartData, setCursorId, isPlaceholderData }) => {
+  const isPreviousButtonDisabled = !chartData?.hasPrevious || isPlaceholderData;
+  const isNextButtonDisabled = !chartData?.hasNext || isPlaceholderData;
+
+  return (
+    <div className="flex justify-center items-center">
+      <Button
+        styles={`z-30 px-4 h-full cursor-pointer group focus:outline-none ${isPreviousButtonDisabled && "hover:cursor-default"}`}
+        onClick={() => setCursorId(chartData?.previousCursorId)}
+        isDisabled={isPreviousButtonDisabled}
+      >
+        <LeftCarouselIcon isDisabled={isPreviousButtonDisabled} />
+      </Button>
+      <span className="text-14">
+        {changeDateWithDotFormat(chartData?.items[0]?.dates[0]) +
+          " ~ " +
+          changeDateWithDotFormat(
+            chartData?.items[0]?.dates[chartData?.items[0]?.dates.length - 1]
+          )}
+      </span>
+      <Button
+        styles={`z-30 px-4 h-full cursor-pointer group focus:outline-none ${isNextButtonDisabled && "hover:cursor-default"}`}
+        onClick={() => setCursorId(chartData?.nextCursorId)}
+        isDisabled={isNextButtonDisabled}
+      >
+        <RightCarouselIcon isDisabled={isNextButtonDisabled} />
+      </Button>
+    </div>
+  );
+};
+
+export default GroupPeriodPagination;
+
+GroupPeriodPagination.propTypes = {
+  chartData: PropTypes.shape({
+    groupId: PropTypes.string.isRequired,
+    keywordIdList: PropTypes.arrayOf(PropTypes.string).isRequired,
+    items: PropTypes.arrayOf(
+      PropTypes.shape({
+        name: PropTypes.string,
+        postCountList: PropTypes.arrayOf(PropTypes.number),
+        likeCountList: PropTypes.arrayOf(PropTypes.number),
+        commentCountList: PropTypes.arrayOf(PropTypes.number),
+        dates: PropTypes.arrayOf(PropTypes.string),
+      })
+    ).isRequired,
+    hasPrevious: PropTypes.bool.isRequired,
+    hasNext: PropTypes.bool.isRequired,
+    cursorId: PropTypes.string.isRequired,
+    previousCursorId: PropTypes.string.isRequired,
+    nextCursorId: PropTypes.string.isRequired,
+  }).isRequired,
+  setCursorId: PropTypes.func.isRequired,
+  isPlaceholderData: PropTypes.bool.isRequired,
+};

--- a/src/components/Pagination/PeriodPagination.jsx
+++ b/src/components/Pagination/PeriodPagination.jsx
@@ -27,7 +27,7 @@ const PeriodPagination = ({ chartData, setCursorId, isPlaceholderData }) => {
         onClick={() => handlePagingClick("previous")}
         disabled={isPreviousButtonDisabled}
       >
-        <LeftCarouselIcon isDisabled={!chartData?.hasPrevious || isPlaceholderData} />
+        <LeftCarouselIcon isDisabled={isPreviousButtonDisabled} />
       </button>
       <span className="text-14">
         {changeDateWithDotFormat(chartData?.dates[0]) +
@@ -40,7 +40,7 @@ const PeriodPagination = ({ chartData, setCursorId, isPlaceholderData }) => {
         onClick={() => handlePagingClick("next")}
         disabled={isNextButtonDisabled}
       >
-        <RightCarouselIcon isDisabled={!chartData?.hasNext || isPlaceholderData} />
+        <RightCarouselIcon isDisabled={isNextButtonDisabled} />
       </button>
     </div>
   );

--- a/src/components/UI/Error.jsx
+++ b/src/components/UI/Error.jsx
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 const Error = ({ errorMessage }) => {
   return (
     <main className="flex-center w-full h-full">
-      <h1 className="text-18 text-red-400">{errorMessage} 😅</h1>
+      <h1 className="text-18 text-red-400">{errorMessage}</h1>
     </main>
   );
 };

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -16,6 +16,7 @@ export const ERROR_MESSAGE = Object.freeze({
   NEW_GROUP_EMPTY_INPUT_VALUE: "그룹명을 입력해주세요.",
   KEYWORD_EMPTY_INPUT_VALUE: "키워드를 입력해주세요.",
   CREATE_KEYWORD_ERROR: "새로운 키워드 생성에 실패하였습니다.",
+  KEYWORD_DUPLICATED_INPUT_VALUE: "이미 키워드가 필터로 등록되어 있어요.",
   SIGN_IN_ERROR: "로그인에 실패하였습니다.",
   FETCH_POSTS: "블로그 정보를 불러오지 못했습니다.",
 });
@@ -31,6 +32,7 @@ export const PERIOD_TYPE = Object.freeze({
 
 export const POST_LISTS = Object.freeze({
   DEFAULT_INCLUDED_KEYWORD: "",
+  DEFAULT_EXCLUDED_KEYWORD: "",
   DEFAULT_LIMIT: 10,
   DEFAULT_CURSOR_ID: "",
 });

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -31,8 +31,8 @@ export const PERIOD_TYPE = Object.freeze({
 });
 
 export const POST_LISTS = Object.freeze({
-  DEFAULT_INCLUDED_KEYWORD: "",
-  DEFAULT_EXCLUDED_KEYWORD: "",
+  DEFAULT_INCLUDED_KEYWORD: [],
+  DEFAULT_EXCLUDED_KEYWORD: [],
   DEFAULT_LIMIT: 10,
   DEFAULT_CURSOR_ID: "",
 });

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -44,3 +44,9 @@ export const SIGNATURE_COLOR = Object.freeze({
   VIA: "#009F55",
   TO: "#00ED64",
 });
+
+export const GROUP_CHART_TYPE = Object.freeze({
+  POST: "주간 게시물 수",
+  LIKE: "주간 공감 수",
+  COMMENT: "주간 댓글 수",
+});

--- a/src/pages/GroupPage.jsx
+++ b/src/pages/GroupPage.jsx
@@ -1,8 +1,10 @@
 import { useParams } from "react-router-dom";
 
 import asyncGetUserGroup from "../api/group/asyncGetUserGroup";
+import GroupPeriodPostCountCard from "../components/Card/Chart/GroupPeriodPostCountCard";
 import DashboardHeader from "../components/Header/DashboardHeader";
 import DashboardSidebar from "../components/Sidebar/DashboardSidebar";
+import { GROUP_CHART_TYPE } from "../config/constants";
 import useNoSignInRedirect from "../hooks/useNoSignInRedirect";
 import useBoundStore from "../store/client/useBoundStore";
 import { useQuery } from "@tanstack/react-query";
@@ -20,28 +22,53 @@ const GroupPage = () => {
     queryKey: ["userGroupList"],
     queryFn: () => asyncGetUserGroup(userUid),
     enabled: hasUserUid,
+    staleTime: 3 * 1000,
   });
 
   const isError = isUserGroupListError || userGroupList?.message?.includes("Error occured");
 
-  if (userGroupList?.groupListLength > 0 && userGroupList?.groupListResult?.length > 0) {
-    setUserGroupList(userGroupList?.groupListResult);
+  if (isError) {
+    return (
+      <main className="flex flex-center mx-auto w-full h-screen max-w-1440">
+        차트를 불러오는데 실패했습니다. 잠시 후 다시 시도해주시기 바랍니다.
+      </main>
+    );
   }
 
   if (userGroupList === undefined) {
     return null;
   }
 
+  if (userGroupList?.groupListLength > 0 && userGroupList?.groupListResult?.length > 0) {
+    setUserGroupList(userGroupList?.groupListResult);
+  }
+
   return (
     <main className="flex justify-start items-start mx-auto pt-67 h-screen w-full max-w-1440">
       <DashboardSidebar userGroupList={userGroupList?.groupListResult} groupId={groupId} />
-      <section className="w-full h-full flex flex-col justify-start">
+      <section className="flex flex-col justify-start w-full">
         <DashboardHeader userGroupList={userGroupList?.groupListResult} groupId={groupId} />
-        {isError && (
-          <div className="flex flex-center w-full h-full">
-            에러가 발생하였습니다. 잠시 후 다시 시도해주시기 바랍니다.
+        <article className="flex flex-col border-l-1 border-b-2 border-r-2 border-slate-200/80 shadow-md w-full h-full mb-30">
+          <div className="flex flex-col gap-10 p-10 w-full h-full">
+            <GroupPeriodPostCountCard
+              groupChartType={GROUP_CHART_TYPE.POST}
+              groupId={groupId}
+              hasUserUid={hasUserUid}
+            />
+            <div className="flex gap-10">
+              <GroupPeriodPostCountCard
+                groupChartType={GROUP_CHART_TYPE.LIKE}
+                groupId={groupId}
+                hasUserUid={hasUserUid}
+              />
+              <GroupPeriodPostCountCard
+                groupChartType={GROUP_CHART_TYPE.COMMENT}
+                groupId={groupId}
+                hasUserUid={hasUserUid}
+              />
+            </div>
           </div>
-        )}
+        </article>
       </section>
     </main>
   );

--- a/src/pages/KeywordPage.jsx
+++ b/src/pages/KeywordPage.jsx
@@ -8,7 +8,7 @@ import PeriodPostCountCard from "../components/Card/Chart/PeriodPostCountCard";
 import PeriodPostLikeCard from "../components/Card/Chart/PeriodPostLikeCard";
 import TodayPostCountCard from "../components/Card/Chart/TodayPostCountCard";
 import PostCardList from "../components/Card/Post/PostCardList";
-import PostListFilter from "../components/Filter/PostListFilter";
+import PostListFilter from "../components/Card/Post/PostListFilter";
 import DashboardHeader from "../components/Header/DashboardHeader";
 import DashboardSidebar from "../components/Sidebar/DashboardSidebar";
 import useNoSignInRedirect from "../hooks/useNoSignInRedirect";
@@ -20,6 +20,10 @@ const KeywordPage = () => {
 
   const { groupId, keywordId } = useParams();
   const [dashboardType, setDashboardType] = useState("chart");
+  const [subKeywordList, setSubKeywordList] = useState({
+    includedKeyword: [],
+    excludedKeyword: [],
+  });
 
   const setUserGroupList = useBoundStore((state) => state.setUserGroupList);
   const userUid = useBoundStore((state) => state.userInfo.uid);
@@ -95,7 +99,13 @@ const KeywordPage = () => {
                   </div>
                 </div>
               ) : (
-                <PostCardList keywordId={keywordId} />
+                <>
+                  <PostListFilter
+                    subKeywordList={subKeywordList}
+                    setSubKeywordList={setSubKeywordList}
+                  />
+                  <PostCardList keywordId={keywordId} subKeywordList={subKeywordList} />
+                </>
               )}
             </>
           )}

--- a/src/pages/KeywordPage.jsx
+++ b/src/pages/KeywordPage.jsx
@@ -20,7 +20,7 @@ const KeywordPage = () => {
 
   const { groupId, keywordId } = useParams();
   const [dashboardType, setDashboardType] = useState("chart");
-  const [subKeywordList, setSubKeywordList] = useState({
+  const [filterList, setFilterList] = useState({
     includedKeyword: [],
     excludedKeyword: [],
   });
@@ -100,11 +100,8 @@ const KeywordPage = () => {
                 </div>
               ) : (
                 <>
-                  <PostListFilter
-                    subKeywordList={subKeywordList}
-                    setSubKeywordList={setSubKeywordList}
-                  />
-                  <PostCardList keywordId={keywordId} subKeywordList={subKeywordList} />
+                  <PostListFilter filterList={filterList} setFilterList={setFilterList} />
+                  <PostCardList keywordId={keywordId} filterList={filterList} />
                 </>
               )}
             </>

--- a/src/pages/KeywordPage.jsx
+++ b/src/pages/KeywordPage.jsx
@@ -8,6 +8,7 @@ import PeriodPostCountCard from "../components/Card/Chart/PeriodPostCountCard";
 import PeriodPostLikeCard from "../components/Card/Chart/PeriodPostLikeCard";
 import TodayPostCountCard from "../components/Card/Chart/TodayPostCountCard";
 import PostCardList from "../components/Card/Post/PostCardList";
+import PostListFilter from "../components/Filter/PostListFilter";
 import DashboardHeader from "../components/Header/DashboardHeader";
 import DashboardSidebar from "../components/Sidebar/DashboardSidebar";
 import useNoSignInRedirect from "../hooks/useNoSignInRedirect";

--- a/src/pages/KeywordPage.jsx
+++ b/src/pages/KeywordPage.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 
 import asyncGetUserGroup from "../api/group/asyncGetUserGroup";
@@ -24,11 +24,17 @@ const KeywordPage = () => {
     includedKeyword: [],
     excludedKeyword: [],
   });
-
   const setUserGroupList = useBoundStore((state) => state.setUserGroupList);
   const userUid = useBoundStore((state) => state.userInfo.uid);
   const hasUserUid = !!userUid;
   const hasKeywordId = !!keywordId;
+
+  useEffect(() => {
+    setFilterList(() => ({
+      includedKeyword: [],
+      excludedKeyword: [],
+    }));
+  }, [keywordId, setFilterList]);
 
   const { data: userGroupList, isError: isUserGroupListError } = useQuery({
     queryKey: ["userGroupList"],

--- a/src/pages/KeywordPage.jsx
+++ b/src/pages/KeywordPage.jsx
@@ -3,7 +3,9 @@ import { useParams } from "react-router-dom";
 
 import asyncGetUserGroup from "../api/group/asyncGetUserGroup";
 import asyncGetKeyword from "../api/keyword/asyncGetKeyword";
+import PeriodPostCommentCard from "../components/Card/Chart/PeriodPostCommentCard";
 import PeriodPostCountCard from "../components/Card/Chart/PeriodPostCountCard";
+import PeriodPostLikeCard from "../components/Card/Chart/PeriodPostLikeCard";
 import TodayPostCountCard from "../components/Card/Chart/TodayPostCountCard";
 import PostCardList from "../components/Card/Post/PostCardList";
 import DashboardHeader from "../components/Header/DashboardHeader";
@@ -85,6 +87,10 @@ const KeywordPage = () => {
                   <div className="flex gap-10 w-full">
                     <TodayPostCountCard keywordId={keywordId} />
                     <PeriodPostCountCard keywordId={keywordId} />
+                  </div>
+                  <div className="flex gap-10 w-full">
+                    <PeriodPostLikeCard keywordId={keywordId} />
+                    <PeriodPostCommentCard keywordId={keywordId} />
                   </div>
                 </div>
               ) : (


### PR DESCRIPTION
## 이슈

- close #24 
- (참고) 백엔드 API https://github.com/Team-Bloblow/Bloblow-Server/pull/35

## 구현 화면
<img width="700" alt="image" src="https://github.com/user-attachments/assets/2750d0ff-0e6a-47ae-b949-c3183950e166">

## 상세 설명

- 포힘/제외 키워드로 게시물 필터링 UI를 구현했습니다. 
- 포함/제외 키워드는 일회성 필터링을 위한 값으로, 클라이언트 상태로 관리합니다.
   - 기존 DB로 관리했던 맥락이 있어 논의결과에 따라 DB schema 수정이 필요할 수 있습니다.
- 필터는 "필터 적용" 버튼을 눌러야 실제 검색 결과를 불러옵니다.
   - 포함/제외 키워드는 자식 컴포넌트 로컬 상태로 관리됩니다. "필터 적용" 버튼 클릭시 해당 키워드 필터가 부모 컴포넌트 상태를 업데이트하여 실제 fetch를 진행합니다.
   - 포함/제외 키워드는 클라이언트에서 배열로 관리하며, 서버로 전달할 때 문자열로 변환하여 params에 담아 request를 보냅니다.
- 직전 필터링 조건과 동일한 상태로 재검색하려고 할 경우 검색이 처리되지 않도록 방지하였습니다.
- 필터는 칩으로 추가 및 제거할 수 있습니다.

## 참고사항

- 현재 스펙에 포함되지 않은 사항 / Known Issue
   - 필터 개수 및 UI 영역 제한: 다수의 필터 추가시 화면 영역이 늘어날 수 있습니다.
   - 편의성을 위해 이전에 사용했던 포함/제외 키워드를 불러오는 기능은 구현여부 검토가 필요합니다.
- 별도 라이브러리는 설치하지 않았습니다.
- 오늘 11월 15일 커밋 중 중복이 있어 검토 중 중복된 커밋은 넘어가주셔도 무방하겠습니다.

## PR 체크 사항

- [ ] conflict를 모두 해결하였습니다.
- [ ] 가장 최신 dev 브랜치를 pull 하였습니다.
- [ ] 코드 컨벤션을 모두 확인하였습니다.
- [ ] `console.log`나 주석 여부를 확인하였습니다.
- [ ] 브랜치명을 확인하였습니다.
- [ ] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!
- [ ] `API 명세서`를 확인하였으며 동기화 하였습니다.

## 리뷰 반영사항

-

## 리뷰 마감시간

- 2024년 11월 15일 오후 12시 30분