### PR TITLE
Fix: Query가 invalidate 되지 않는 이슈 해결 및 키워드 대시보드 스타일 수정

### DIFF
--- a/src/components/Card/Chart/GroupPeriodPostCountCard.jsx
+++ b/src/components/Card/Chart/GroupPeriodPostCountCard.jsx
@@ -44,7 +44,7 @@ const GroupPeriodPostCountCard = ({ groupChartType, groupId, hasUserUid }) => {
 
   if (isError) {
     return (
-      <article className="flex-col-center w-full h-full border-2 rounded-md">
+      <article className="flex-col-center w-full border-2 rounded-md">
         에러가 발생하였습니다. 잠시 후 다시 시도해주시기 바랍니다.
       </article>
     );
@@ -56,12 +56,12 @@ const GroupPeriodPostCountCard = ({ groupChartType, groupId, hasUserUid }) => {
 
   return (
     <article
-      className={`flex flex-col gap-6 h-full p-10 border-2 rounded-md ${groupChartType === GROUP_CHART_TYPE.POST ? "w-full" : "w-1/2"}`}
+      className={`flex flex-col gap-6 p-10 border-2 rounded-md ${groupChartType === GROUP_CHART_TYPE.POST ? "w-full" : "w-1/2"}`}
     >
       <span className="flex-shrink-0 bg-green-100/20 px-10 py-5 rounded-[2px]">
         {groupChartType}
       </span>
-      <div className="flex-col-center h-full gap-5">
+      <div className="flex-col-center gap-5">
         <GroupLineChart groupChartType={groupChartType} chartData={groupPostCountData} />
         <GroupPeriodPagination
           chartData={groupPostCountData}

--- a/src/components/Card/Chart/PeriodPostCommentCard.jsx
+++ b/src/components/Card/Chart/PeriodPostCommentCard.jsx
@@ -34,7 +34,7 @@ const PeriodPostCommentCard = ({ keywordId }) => {
   }
 
   return (
-    <article className="flex flex-col gap-6 w-1/2 h-full p-10 border-2 rounded-md">
+    <article className="flex flex-col gap-6 w-1/2 p-10 border-2 rounded-md">
       <span className="flex-shrink-0 bg-green-100/20 px-10 py-5 rounded-[2px]">주간 댓글 수</span>
       <div className="flex-col-center">
         <BarChart chartData={chartData} />

--- a/src/components/Card/Chart/PeriodPostCountCard.jsx
+++ b/src/components/Card/Chart/PeriodPostCountCard.jsx
@@ -34,7 +34,7 @@ const PeriodPostCountCard = ({ keywordId }) => {
   }
 
   return (
-    <article className="flex flex-col gap-6 w-full h-full p-10 border-2 rounded-md">
+    <article className="flex flex-col gap-6 w-full p-10 border-2 rounded-md">
       <span className="flex-shrink-0 bg-green-100/20 px-10 py-5 rounded-[2px]">주간 게시물 수</span>
       <div className="flex-col-center">
         <LineChart chartData={chartData} />

--- a/src/components/Card/Chart/PeriodPostLikeCard.jsx
+++ b/src/components/Card/Chart/PeriodPostLikeCard.jsx
@@ -34,7 +34,7 @@ const PeriodPostLikeCard = ({ keywordId }) => {
   }
 
   return (
-    <article className="flex flex-col gap-6 w-1/2 h-full p-10 border-2 rounded-md">
+    <article className="flex flex-col gap-6 w-1/2 p-10 border-2 rounded-md">
       <span className="flex-shrink-0 bg-green-100/20 px-10 py-5 rounded-[2px]">주간 공감 수</span>
       <div className="flex-col-center">
         <LineChart chartData={chartData} />

--- a/src/components/Card/Chart/TodayPostCountCard.jsx
+++ b/src/components/Card/Chart/TodayPostCountCard.jsx
@@ -28,9 +28,9 @@ const TodayPostCountCard = ({ keywordId }) => {
   const lessThanYesterday = Number(chartData.diffPostCount) < 0;
 
   return (
-    <article className="flex flex-col gap-40 w-[35%] h-full p-10 border-2 rounded-md flex-shrink-0">
+    <article className="flex flex-col gap-40 w-[35%] p-10 border-2 rounded-md flex-shrink-0">
       <span className="bg-green-100/20 px-10 py-5 rounded-[2px]">오늘의 게시물</span>
-      <div className="flex flex-col gap-10 h-full">
+      <div className="flex flex-col gap-10 flex-grow">
         <div className="flex justify-center">
           {isEqual && <EndashIcon className="size-90" />}
           {greaterThanYesterday && <UpwardArrowIcon className="size-90" />}

--- a/src/components/Card/Post/PostCardList.jsx
+++ b/src/components/Card/Post/PostCardList.jsx
@@ -60,7 +60,7 @@ const PostCardList = ({ keywordId, filterList }) => {
           });
         })
       )}
-      <div className="w-full h-10 flex-shrink-0" ref={observeRef} />
+      <div ref={observeRef} />
     </article>
   );
 };

--- a/src/components/Modal/CreateKeywordModal.jsx
+++ b/src/components/Modal/CreateKeywordModal.jsx
@@ -71,20 +71,32 @@ const CreateKeywordModal = ({ createType, selectedGroupId, selectedGroupName }) 
           newGroup: ERROR_MESSAGE.NEW_GROUP_EMPTY_INPUT_VALUE,
         }));
         return;
+      } else {
+        setErrorMessage((prev) => ({
+          ...prev,
+          newGroup: "",
+        }));
       }
     } else {
-      if (keywordValue === "" || selectedGroup.name === "") {
-        if (keywordValue === "") {
-          setErrorMessage((prev) => ({
-            ...prev,
-            keyword: ERROR_MESSAGE.KEYWORD_EMPTY_INPUT_VALUE,
-          }));
-        }
-        if (selectedGroup.name === "") {
-          setErrorMessage((prev) => ({ ...prev, group: ERROR_MESSAGE.MUST_GROUP_SELECT }));
-        }
+      if (selectedGroup.name === "") {
+        setErrorMessage((prev) => ({ ...prev, group: ERROR_MESSAGE.MUST_GROUP_SELECT }));
         return;
+      } else {
+        setErrorMessage((prev) => ({ ...prev, group: "" }));
       }
+    }
+
+    if (keywordValue === "") {
+      setErrorMessage((prev) => ({
+        ...prev,
+        keyword: ERROR_MESSAGE.KEYWORD_EMPTY_INPUT_VALUE,
+      }));
+      return;
+    } else {
+      setErrorMessage((prev) => ({
+        ...prev,
+        keyword: "",
+      }));
     }
 
     const keywordInfo = {

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -1,4 +1,4 @@
-export const BASE_URL = "http://localhost:3000";
+export const BASE_URL = "https://bloblow-api.onrender.com";
 
 export const MODAL_TYPE = Object.freeze({
   CREATE_KEYWORD: {

--- a/src/pages/GroupPage.jsx
+++ b/src/pages/GroupPage.jsx
@@ -19,7 +19,7 @@ const GroupPage = () => {
   const hasUserUid = !!userUid;
 
   const { data: userGroupList, isError: isUserGroupListError } = useQuery({
-    queryKey: ["userGroupList"],
+    queryKey: ["userGroupList", userUid],
     queryFn: () => asyncGetUserGroup(userUid),
     enabled: hasUserUid,
     staleTime: 3 * 1000,

--- a/src/pages/GroupPage.jsx
+++ b/src/pages/GroupPage.jsx
@@ -48,8 +48,8 @@ const GroupPage = () => {
       <DashboardSidebar userGroupList={userGroupList?.groupListResult} groupId={groupId} />
       <section className="flex flex-col justify-start w-full">
         <DashboardHeader userGroupList={userGroupList?.groupListResult} groupId={groupId} />
-        <article className="flex flex-col border-l-1 border-b-2 border-r-2 border-slate-200/80 shadow-md w-full h-full mb-30">
-          <div className="flex flex-col gap-10 p-10 w-full h-full">
+        <article className="flex flex-col border-l-1 border-b-2 border-r-2 border-slate-200/80 shadow-md w-full mb-30">
+          <div className="flex flex-col gap-10 p-10 w-full">
             <GroupPeriodPostCountCard
               groupChartType={GROUP_CHART_TYPE.POST}
               groupId={groupId}

--- a/src/pages/KeywordPage.jsx
+++ b/src/pages/KeywordPage.jsx
@@ -65,14 +65,14 @@ const KeywordPage = () => {
   return (
     <main className="flex justify-start items-start mx-auto pt-67 h-screen w-full max-w-1440">
       <DashboardSidebar userGroupList={userGroupList?.groupListResult} groupId={groupId} />
-      <section className="w-full flex flex-col justify-start">
+      <section className="w-full h-full flex flex-col justify-start">
         <DashboardHeader
           userGroupList={userGroupList?.groupListResult}
           groupId={groupId}
           specificKeywordData={specificKeywordData}
           keywordId={keywordId}
         />
-        <article className="flex flex-col border-l-1 border-b-2 border-r-2 border-slate-200/80 shadow-md w-full h-full mb-30">
+        <article className={`flex flex-col border-l-1 border-b-2 border-r-2 border-slate-200/80 shadow-md w-full ${dashboardType === "post" && "h-full"}`}>
           <div className="flex gap-10 w-full h-40 px-10 bg-green-100/30">
             <button
               className={`p-5 h-full ${dashboardType === "chart" ? "font-bold" : "text-gray-500"} hover:text-green-800`}

--- a/src/pages/KeywordPage.jsx
+++ b/src/pages/KeywordPage.jsx
@@ -37,7 +37,7 @@ const KeywordPage = () => {
   }, [keywordId, setFilterList]);
 
   const { data: userGroupList, isError: isUserGroupListError } = useQuery({
-    queryKey: ["userGroupList"],
+    queryKey: ["userGroupList", userUid],
     queryFn: () => asyncGetUserGroup(userUid),
     enabled: hasUserUid,
   });
@@ -65,7 +65,9 @@ const KeywordPage = () => {
   return (
     <main className="flex justify-start items-start mx-auto pt-67 h-screen w-full max-w-1440">
       <DashboardSidebar userGroupList={userGroupList?.groupListResult} groupId={groupId} />
-      <section className="w-full flex flex-col justify-start">
+      <section
+        className={`w-full flex flex-col justify-start ${dashboardType !== "chart" && "h-full"}`}
+      >
         <DashboardHeader
           userGroupList={userGroupList?.groupListResult}
           groupId={groupId}
@@ -73,7 +75,7 @@ const KeywordPage = () => {
           keywordId={keywordId}
         />
         <article
-          className={`flex flex-col border-l-1 border-b-2 border-r-2 border-slate-200/80 shadow-md w-full ${dashboardType === "post" && "h-full"}`}
+          className={`flex flex-col border-l-1 border-b-2 border-r-2 border-slate-200/80 shadow-md w-full ${dashboardType !== "chart" && "h-full"}`}
         >
           <div className="flex gap-10 w-full h-40 px-10 bg-green-100/30">
             <button
@@ -107,10 +109,10 @@ const KeywordPage = () => {
                   </div>
                 </div>
               ) : (
-                <>
+                <div className="flex flex-col h-full">
                   <PostListFilter filterList={filterList} setFilterList={setFilterList} />
                   <PostCardList keywordId={keywordId} filterList={filterList} />
-                </>
+                </div>
               )}
             </>
           )}

--- a/src/pages/KeywordPage.jsx
+++ b/src/pages/KeywordPage.jsx
@@ -65,14 +65,14 @@ const KeywordPage = () => {
   return (
     <main className="flex justify-start items-start mx-auto pt-67 h-screen w-full max-w-1440">
       <DashboardSidebar userGroupList={userGroupList?.groupListResult} groupId={groupId} />
-      <section className="w-full h-full flex flex-col justify-start">
+      <section className="w-full flex flex-col justify-start">
         <DashboardHeader
           userGroupList={userGroupList?.groupListResult}
           groupId={groupId}
           specificKeywordData={specificKeywordData}
           keywordId={keywordId}
         />
-        <article className="flex flex-col border-r-2 border-slate-200/80 shadow-sm h-full">
+        <article className="flex flex-col border-l-1 border-b-2 border-r-2 border-slate-200/80 shadow-md w-full h-full mb-30">
           <div className="flex gap-10 w-full h-40 px-10 bg-green-100/30">
             <button
               className={`p-5 h-full ${dashboardType === "chart" ? "font-bold" : "text-gray-500"} hover:text-green-800`}
@@ -94,12 +94,12 @@ const KeywordPage = () => {
           ) : (
             <>
               {dashboardType === "chart" ? (
-                <div className="flex flex-col p-10 w-full h-full">
-                  <div className="flex gap-10 w-full">
+                <div className="flex flex-col gap-10 p-10 w-full h-full">
+                  <div className="flex gap-10 w-full h-full">
                     <TodayPostCountCard keywordId={keywordId} />
                     <PeriodPostCountCard keywordId={keywordId} />
                   </div>
-                  <div className="flex gap-10 w-full">
+                  <div className="flex gap-10 w-full h-full">
                     <PeriodPostLikeCard keywordId={keywordId} />
                     <PeriodPostCommentCard keywordId={keywordId} />
                   </div>

--- a/src/pages/KeywordPage.jsx
+++ b/src/pages/KeywordPage.jsx
@@ -72,7 +72,9 @@ const KeywordPage = () => {
           specificKeywordData={specificKeywordData}
           keywordId={keywordId}
         />
-        <article className={`flex flex-col border-l-1 border-b-2 border-r-2 border-slate-200/80 shadow-md w-full ${dashboardType === "post" && "h-full"}`}>
+        <article
+          className={`flex flex-col border-l-1 border-b-2 border-r-2 border-slate-200/80 shadow-md w-full ${dashboardType === "post" && "h-full"}`}
+        >
           <div className="flex gap-10 w-full h-40 px-10 bg-green-100/30">
             <button
               className={`p-5 h-full ${dashboardType === "chart" ? "font-bold" : "text-gray-500"} hover:text-green-800`}


### PR DESCRIPTION
## 이슈

- close #35 

## 구현 화면

### 키워드 대시보드: 게시물 없을 시

![image](https://github.com/user-attachments/assets/f92b8f33-fd21-4df3-ab34-f33035a87516)

### 키워드 대시보드: 차트 페이지

![image](https://github.com/user-attachments/assets/8aae8503-b610-49ec-a1fa-8a61c5163bb5)

## 상세 설명

- 키워드 대시보드 관련 스타일을 보기 좋게 수정하였습니다. 기존에는 gap과 높이 등이 불규칙하게 되어 있어서 수정하였습니다.
- 대시보드에서 키워드 추가 시, 바로 사이드바에 반영이 되지 않는 부분을 수정하였습니다. groupPage와 keywordPage에서의 `useQuery`의 query를 수정하였습니다.

## PR 체크 사항

- [ ] conflict를 모두 해결하였습니다.
- [ ] 가장 최신 dev 브랜치를 pull 하였습니다.
- [ ] 코드 컨벤션을 모두 확인하였습니다.
- [ ] `console.log`나 주석 여부를 확인하였습니다.
- [ ] 브랜치명을 확인하였습니다.
- [ ] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!
- [ ] `API 명세서`를 확인하였으며 동기화 하였습니다.

## 리뷰 반영사항

-

## PR 리뷰 마감 시간

- 2024년 11월 16일 오후 6시까지