### PR TITLE
Feat: 게시물 정렬 및 필터 UI 변경

### DIFF
--- a/src/api/post/asyncGetPosts.js
+++ b/src/api/post/asyncGetPosts.js
@@ -5,8 +5,10 @@ const asyncGetPosts = async (
   cursorId = POST_LISTS.DEFAULT_CURSOR_ID,
   {
     keywordId,
+    order = POST_LISTS.DEFAULT_ORDER,
     includedKeyword = POST_LISTS.DEFAULT_INCLUDED_KEYWORD,
     excludedKeyword = POST_LISTS.DEFAULT_EXCLUDED_KEYWORD,
+    isAd = POST_LISTS.DEFAULT_IS_AD,
     limit = POST_LISTS.DEFAULT_LIMIT,
   }
 ) => {
@@ -14,7 +16,7 @@ const asyncGetPosts = async (
   const excludedKeywordParams = excludedKeyword.length === 0 ? "" : excludedKeyword.join();
   const fetchInfo = {
     url: `${BASE_URL}/posts/${keywordId}`,
-    params: `?includedKeyword=${includedKeywordParams}&excludedKeyword=${excludedKeywordParams}&limit=${limit}&cursorId=${cursorId}`,
+    params: `?order=${order}&includedKeyword=${includedKeywordParams}&excludedKeyword=${excludedKeywordParams}&isAd=${isAd}$limit=${limit}&cursorId=${cursorId}`,
   };
 
   const response = await fetchHandler(fetchInfo);

--- a/src/components/Card/Post/PostCardList.jsx
+++ b/src/components/Card/Post/PostCardList.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useRef } from "react";
 
 import asyncGetPosts from "../../../api/post/asyncGetPosts";
 import { ERROR_MESSAGE } from "../../../config/constants";
@@ -6,9 +6,10 @@ import useInfiniteData from "../../../hooks/useInfiniteData";
 import Error from "../../UI/Error";
 import Loading from "../../UI/Loading";
 import PostCard from "./PostCard";
+import PostListFilter from "./PostListFilter";
 import PropTypes from "prop-types";
 
-const PostCardList = ({ keywordId, filterList, setHasPost }) => {
+const PostCardList = ({ keywordId, filterList, setFilterList, resetFilterList }) => {
   const observeRef = useRef(null);
   const observeRootRef = useRef(null);
 
@@ -32,12 +33,6 @@ const PostCardList = ({ keywordId, filterList, setHasPost }) => {
   const { data: postResponse, isPending, isError } = useInfiniteData(infiniteDataArgument);
   const hasPostResponse = postResponse?.pages[0]?.items?.length > 0;
 
-  useEffect(() => {
-    if (hasPostResponse) {
-      setHasPost(true);
-    }
-  }, [hasPostResponse, setHasPost]);
-
   if (isError || postResponse?.pages[0]?.message?.includes("Error occured")) {
     return <Error errorMessage={ERROR_MESSAGE.FETCH_POSTS} />;
   }
@@ -50,22 +45,29 @@ const PostCardList = ({ keywordId, filterList, setHasPost }) => {
       {isPending ? (
         <Loading width={100} height={100} text={""} />
       ) : hasPostResponse ? (
-        postResponse?.pages?.map((page) => {
-          return page.items?.map((postInfo) => {
-            return (
-              <PostCard
-                key={postInfo?._id}
-                postTitle={postInfo?.title}
-                postDescription={postInfo?.description}
-                likeCount={postInfo?.likeCount}
-                commentCount={postInfo?.commentCount}
-                link={postInfo?.link}
-                createdAt={postInfo?.createdAt}
-                isAd={postInfo?.isAd ?? false}
-              />
-            );
-          });
-        })
+        <>
+          <PostListFilter
+            filterList={filterList}
+            setFilterList={setFilterList}
+            resetFilterList={resetFilterList}
+          />
+          {postResponse?.pages?.map((page) => {
+            return page.items?.map((postInfo) => {
+              return (
+                <PostCard
+                  key={postInfo?._id}
+                  postTitle={postInfo?.title}
+                  postDescription={postInfo?.description}
+                  likeCount={postInfo?.likeCount}
+                  commentCount={postInfo?.commentCount}
+                  link={postInfo?.link}
+                  createdAt={postInfo?.createdAt}
+                  isAd={postInfo?.isAd ?? false}
+                />
+              );
+            });
+          })}
+        </>
       ) : (
         <p className="w-full h-full flex-center text-22">확인할 수 있는 게시물이 없어요</p>
       )}
@@ -84,5 +86,6 @@ PostCardList.propTypes = {
     excludedKeyword: PropTypes.arrayOf(PropTypes.string.isRequired),
     isAd: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]).isRequired,
   }),
-  setHasPost: PropTypes.func.isRequired,
+  setFilterList: PropTypes.func.isRequired,
+  resetFilterList: PropTypes.func.isRequired,
 };

--- a/src/components/Card/Post/PostCardList.jsx
+++ b/src/components/Card/Post/PostCardList.jsx
@@ -17,8 +17,10 @@ const PostCardList = ({ keywordId, filterList }) => {
     queryFn: asyncGetPosts,
     options: {
       keywordId,
+      order: filterList.order,
       includedKeyword: filterList.includedKeyword,
       excludedKeyword: filterList.excludedKeyword,
+      isAd: filterList.isAd,
       limit: 5,
     },
     initialPageParam: "",
@@ -70,7 +72,9 @@ export default PostCardList;
 PostCardList.propTypes = {
   keywordId: PropTypes.string.isRequired,
   filterList: PropTypes.shape({
+    order: PropTypes.string.isRequired,
     includedKeyword: PropTypes.arrayOf(PropTypes.string.isRequired),
     excludedKeyword: PropTypes.arrayOf(PropTypes.string.isRequired),
+    isAd: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]).isRequired,
   }),
 };

--- a/src/components/Card/Post/PostCardList.jsx
+++ b/src/components/Card/Post/PostCardList.jsx
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useEffect, useRef } from "react";
 
 import asyncGetPosts from "../../../api/post/asyncGetPosts";
 import { ERROR_MESSAGE } from "../../../config/constants";
@@ -32,9 +32,12 @@ const PostCardList = ({ keywordId, filterList, setHasPost }) => {
   const { data: postResponse, isPending, isError } = useInfiniteData(infiniteDataArgument);
   const hasPostResponse = postResponse?.pages[0]?.items?.length > 0;
 
-  if (hasPostResponse) {
-    setHasPost(true);
-  }
+  useEffect(() => {
+    if (hasPostResponse) {
+      setHasPost(true);
+    }
+  }, [hasPostResponse, setHasPost]);
+
   if (isError || postResponse?.pages[0]?.message?.includes("Error occured")) {
     return <Error errorMessage={ERROR_MESSAGE.FETCH_POSTS} />;
   }

--- a/src/components/Card/Post/PostCardList.jsx
+++ b/src/components/Card/Post/PostCardList.jsx
@@ -8,7 +8,7 @@ import Loading from "../../UI/Loading";
 import PostCard from "./PostCard";
 import PropTypes from "prop-types";
 
-const PostCardList = ({ keywordId, filterList }) => {
+const PostCardList = ({ keywordId, filterList, setHasPost }) => {
   const observeRef = useRef(null);
   const observeRootRef = useRef(null);
 
@@ -30,7 +30,11 @@ const PostCardList = ({ keywordId, filterList }) => {
   };
 
   const { data: postResponse, isPending, isError } = useInfiniteData(infiniteDataArgument);
+  const hasPostResponse = postResponse?.pages[0]?.items?.length > 0;
 
+  if (hasPostResponse) {
+    setHasPost(true);
+  }
   if (isError || postResponse?.pages[0]?.message?.includes("Error occured")) {
     return <Error errorMessage={ERROR_MESSAGE.FETCH_POSTS} />;
   }
@@ -42,9 +46,7 @@ const PostCardList = ({ keywordId, filterList }) => {
     >
       {isPending ? (
         <Loading width={100} height={100} text={""} />
-      ) : postResponse?.pages[0]?.items?.length === 0 ? (
-        <p className="w-full h-full flex-center text-22">확인할 수 있는 게시물이 없어요</p>
-      ) : (
+      ) : hasPostResponse ? (
         postResponse?.pages?.map((page) => {
           return page.items?.map((postInfo) => {
             return (
@@ -61,6 +63,8 @@ const PostCardList = ({ keywordId, filterList }) => {
             );
           });
         })
+      ) : (
+        <p className="w-full h-full flex-center text-22">확인할 수 있는 게시물이 없어요</p>
       )}
       <div ref={observeRef} />
     </article>
@@ -77,4 +81,5 @@ PostCardList.propTypes = {
     excludedKeyword: PropTypes.arrayOf(PropTypes.string.isRequired),
     isAd: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]).isRequired,
   }),
+  setHasPost: PropTypes.func.isRequired,
 };

--- a/src/components/Card/Post/PostListFilter.jsx
+++ b/src/components/Card/Post/PostListFilter.jsx
@@ -35,11 +35,11 @@ const PostListFilter = ({ filterList, setFilterList, resetFilterList }) => {
   const buttonInDropDownRef = useRef(null);
 
   const selectedKeywordTypeInDropDownKR =
-    dropDownOpened.type === "keyword-included"
+    dropDownOpened.dropDownType === "keyword-included"
       ? POST_LISTS.INCLUDED_KEYWORD
       : POST_LISTS.EXCLUDED_KEYWORD;
   const selectedKeywordTypeInDropDownEN =
-    dropDownOpened.type === "keyword-included" ? "includedKeyword" : "excludedKeyword";
+    dropDownOpened.dropDownType === "keyword-included" ? "includedKeyword" : "excludedKeyword";
   const keywordFilterCount =
     tempFilterList.includedKeyword.length + tempFilterList.excludedKeyword.length;
 
@@ -246,7 +246,7 @@ const PostListFilter = ({ filterList, setFilterList, resetFilterList }) => {
             <div>
               <span className="text-16 font-semibold">정렬</span>
             </div>
-            <ul ref={buttonInDropDownRef} className="flex flex-col gap-5 border-2">
+            <ul ref={buttonInDropDownRef} className="flex flex-col gap-5">
               <li className="px-3 py-5 rounded-md hover:bg-gray-100">
                 <Button
                   styles="w-full text-left"
@@ -284,13 +284,13 @@ const PostListFilter = ({ filterList, setFilterList, resetFilterList }) => {
             </div>
             <div className="flex flex-row gap-20 p-1 w-full h-40 rounded-lg bg-gray-100">
               <Button
-                styles={`flex-1 p-5 m-1 round-md ${dropDownOpened.type === "keyword-included" && "bg-white"}`}
+                styles={`flex-1 p-5 m-1 round-md ${dropDownOpened.dropDownType === "keyword-included" && "bg-white"}`}
                 onClick={() => handleOpenDropDownClick("keyword-included")}
               >
                 <span>{POST_LISTS.INCLUDED_KEYWORD}</span>
               </Button>
               <Button
-                styles={`flex-1 p-5 m-1 round-md ${dropDownOpened.type !== "keyword-included" && "bg-white"}`}
+                styles={`flex-1 p-5 m-1 round-md ${dropDownOpened.dropDownType !== "keyword-included" && "bg-white"}`}
                 onClick={() => handleOpenDropDownClick("keyword-excluded")}
               >
                 <span>{POST_LISTS.EXCLUDED_KEYWORD}</span>
@@ -329,7 +329,7 @@ const PostListFilter = ({ filterList, setFilterList, resetFilterList }) => {
                           keyword
                         )
                       }
-                      styles={`w-fit px-10 py-5 m-5 border-solid border-2 rounded-xl ${dropDownOpened.type === "keyword-included" ? "bg-green-100 border-green-200" : "bg-red-100 border-red-200"}`}
+                      styles={`w-fit px-10 py-5 m-5 border-solid border-2 rounded-xl font-medium ${dropDownOpened.dropDownType === "keyword-included" ? "bg-green-100 border-green-200" : "bg-red-100 border-red-200"}`}
                     />
                   );
                 })}
@@ -345,7 +345,7 @@ const PostListFilter = ({ filterList, setFilterList, resetFilterList }) => {
             <div>
               <span className="text-16 font-semibold">광고 필터</span>
             </div>
-            <ul ref={buttonInDropDownRef} className="flex flex-col border-2">
+            <ul ref={buttonInDropDownRef} className="flex flex-col">
               <li className="rounded-md hover:bg-gray-100">
                 <Button
                   styles="w-full px-3 py-10 text-left"

--- a/src/components/Card/Post/PostListFilter.jsx
+++ b/src/components/Card/Post/PostListFilter.jsx
@@ -84,6 +84,10 @@ const PostListFilter = ({ filterList, setFilterList, resetFilterList }) => {
           isOpen: false,
           dropDownType: "",
         }));
+        setErrorMessage({
+          includedKeyword: "",
+          excludedKeyword: "",
+        });
         return;
       }
     };
@@ -120,6 +124,10 @@ const PostListFilter = ({ filterList, setFilterList, resetFilterList }) => {
     const hasFilter = filterKeyword.has(trimmedInputValue);
 
     if (hasFilter) {
+      setInputValue({
+        includedKeyword: "",
+        excludedKeyword: "",
+      });
       setErrorMessage((prev) => ({
         ...prev,
         [keywordFilterType]: ERROR_MESSAGE.KEYWORD_DUPLICATED_INPUT_VALUE,
@@ -315,6 +323,11 @@ const PostListFilter = ({ filterList, setFilterList, resetFilterList }) => {
                 placeholder={selectedKeywordTypeInDropDownKR}
               />
             </form>
+            <div className="flex flex-col gap-5">
+              <p className="text-14 text-red-400 font-semibold">
+                {errorMessage[selectedKeywordTypeInDropDownEN]}
+              </p>
+            </div>
             <ul>
               <div className="flex flex-wrap w-full h-full">
                 {tempFilterList[selectedKeywordTypeInDropDownEN]?.map((keyword) => {
@@ -374,11 +387,6 @@ const PostListFilter = ({ filterList, setFilterList, resetFilterList }) => {
           </div>
         )}
       </div>
-      <div className="flex flex-col gap-5">
-        <div className="flex items-center gap-15 w-full"></div>
-        <p className="text-14 text-red-400 font-semibold">{errorMessage.includedKeyword}</p>
-      </div>
-      <p className="text-14 text-red-400 font-semibold">{errorMessage.excludedKeyword}</p>
     </div>
   );
 };

--- a/src/components/Card/Post/PostListFilter.jsx
+++ b/src/components/Card/Post/PostListFilter.jsx
@@ -207,7 +207,7 @@ const PostListFilter = ({ filterList, setFilterList, resetFilterList }) => {
   };
 
   return (
-    <div className="flex flex-col gap-10 w-full px-20 py-10">
+    <div className="flex flex-col gap-10 w-full py-10">
       <div className="relative">
         <ul className="flex gap-10">
           <div>

--- a/src/components/Card/Post/PostListFilter.jsx
+++ b/src/components/Card/Post/PostListFilter.jsx
@@ -1,6 +1,7 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
-import { ERROR_MESSAGE } from "../../../config/constants";
+import { ERROR_MESSAGE, POST_LISTS } from "../../../config/constants";
+import useDropDown from "../../../hooks/useDropDown";
 import KeywordChip from "../../Chip/KeywordChip";
 import Button from "../../UI/Button";
 import Label from "../../UI/Label";
@@ -8,8 +9,10 @@ import PropTypes from "prop-types";
 
 const PostListFilter = ({ filterList, setFilterList }) => {
   const [tempFilterList, setTempFilterList] = useState({
+    order: filterList.includedKeyword,
     includedKeyword: filterList.includedKeyword,
     excludedKeyword: filterList.excludedKeyword,
+    isAd: filterList.isAd,
   });
   const [inputValue, setInputValue] = useState({
     includedKeyword: "",
@@ -19,56 +22,86 @@ const PostListFilter = ({ filterList, setFilterList }) => {
     includedKeyword: "",
     excludedKeyword: "",
   });
+  const [openedDropDownType, setOpenedDropDownType] = useState("");
+  const dropDownBoxRef = useRef(null);
+  const dropDownBoxTextRef = useRef(null);
+  const dropDownRefList = [dropDownBoxRef, dropDownBoxTextRef];
+  const [isDropDownOpen, setIsDropDownOpen] = useDropDown(dropDownRefList, "dropDown");
+
+  const selectedKeywordTypeInDropDownKR =
+    openedDropDownType === "keyword-included"
+      ? POST_LISTS.INCLUDED_KEYWORD
+      : POST_LISTS.EXCLUDED_KEYWORD;
+  const selectedKeywordTypeInDropDownEN =
+    openedDropDownType === "keyword-included" ? "includedKeyword" : "excludedKeyword";
+  const keywordFilterCount =
+    tempFilterList.includedKeyword.length + tempFilterList.excludedKeyword.length;
+  const getSelectedAdFilter = (adFilterType) => {
+    switch (adFilterType) {
+      case "":
+        return POST_LISTS.ISAD_KR.ALL;
+      case true:
+        return POST_LISTS.ISAD_KR.ONLY_ADS;
+      case false:
+        return POST_LISTS.ISAD_KR.NO_ADS;
+    }
+  };
 
   useEffect(() => {
     setTempFilterList(() => ({
+      order: filterList.order,
       includedKeyword: filterList.includedKeyword,
       excludedKeyword: filterList.excludedKeyword,
+      isAd: filterList.isAd,
     }));
-  }, [filterList.includedKeyword, filterList.excludedKeyword]);
+  }, [filterList.order, filterList.includedKeyword, filterList.excludedKeyword, filterList.isAd]);
 
-  const handleFilterInputChange = (e, filterType) => {
-    setInputValue((prev) => ({ ...prev, [filterType]: e.target.value }));
+  const handleDropDownClick = () => {
+    setIsDropDownOpen(!isDropDownOpen);
+  };
+  const handleKeywordFilterInputChange = (e, keywordFilterType) => {
+    setInputValue((prev) => ({ ...prev, [keywordFilterType]: e.target.value }));
     return;
   };
-
-  const handleCreateTempFilterSubmit = (e, filterType) => {
+  const handleCreateTempKeywordFilterSubmit = (e, keywordFilterType) => {
     e.preventDefault();
-    const trimmedInputValue = inputValue[filterType].trim();
+    const trimmedInputValue = inputValue[keywordFilterType].trim();
 
     if (trimmedInputValue === "") {
       return;
     }
-    const hasFilter = Object.values(tempFilterList).some((filter) =>
-      filter.includes(trimmedInputValue)
-    );
+    const filterKeyword = new Set([
+      ...tempFilterList.includedKeyword,
+      ...tempFilterList.excludedKeyword,
+    ]);
+    const hasFilter = filterKeyword.has(trimmedInputValue);
 
     if (hasFilter) {
       setErrorMessage((prev) => ({
         ...prev,
-        [filterType]: ERROR_MESSAGE.KEYWORD_DUPLICATED_INPUT_VALUE,
+        [keywordFilterType]: ERROR_MESSAGE.KEYWORD_DUPLICATED_INPUT_VALUE,
       }));
       return;
     }
 
     setTempFilterList((prev) => ({
       ...prev,
-      [filterType]: [...prev[filterType], trimmedInputValue],
+      [keywordFilterType]: [...prev[keywordFilterType], trimmedInputValue],
     }));
-    setInputValue((prev) => ({ ...prev, [filterType]: "" }));
-    setErrorMessage((prev) => ({ ...prev, [filterType]: "" }));
+    setInputValue((prev) => ({ ...prev, [keywordFilterType]: "" }));
+    setErrorMessage((prev) => ({ ...prev, [keywordFilterType]: "" }));
     return;
   };
-
-  const handleFilterChipRemoveButtonClick = (filterType, filterForRemove) => {
+  const handleKeywordFilterChipRemoveButtonClick = (keywordFilterType, keywordFilterForRemove) => {
     setTempFilterList((prev) => ({
       ...prev,
-      [filterType]: prev[filterType].filter((filter) => filter !== filterForRemove),
+      [keywordFilterType]: prev[keywordFilterType].filter(
+        (filter) => filter !== keywordFilterForRemove
+      ),
     }));
     return;
   };
-
-  const handleFilterApplyButtonClick = () => {
+  const handleAllFilterApplyButtonClick = () => {
     const filters = Object.values(filterList).flat().sort();
     const tempFilters = Object.values(tempFilterList).flat().sort();
     const isEqualFilter = tempFilters.every((filter, index) => filter === filters[index]);
@@ -80,89 +113,196 @@ const PostListFilter = ({ filterList, setFilterList }) => {
     setFilterList(tempFilterList);
     return;
   };
+  const handleOrderDropDownClick = (sortType) => {
+    if (tempFilterList.order === sortType) {
+      return;
+    }
+
+    setTempFilterList((prev) => ({
+      ...prev,
+      order: sortType,
+    }));
+    return;
+  };
+  const handleAdFilterDropDownClick = (adFilterType) => {
+    if (tempFilterList.isAd === adFilterType) {
+      return;
+    }
+
+    setTempFilterList((prev) => ({
+      ...prev,
+      isAd: adFilterType,
+    }));
+    return;
+  };
 
   return (
     <div className="flex flex-col gap-10 w-full px-20 py-10">
-      <div className="flex flex-col gap-5">
-        <div className="flex items-center gap-15 w-full">
-          <form
-            className="w-400 h-40 px-20 flex items-center gap-5 flex-shrink-0 border-2 rounded-md"
-            onSubmit={(e) => handleCreateTempFilterSubmit(e, "includedKeyword")}
+      <div className="relative" onClick={handleDropDownClick}>
+        <ul className="flex gap-10" ref={dropDownBoxRef}>
+          <Button
+            styles="w-110 right-20 px-5 py-4 rounded-[5px] font-medium text-gray-900/80 border-2 border-slate-200/80 font-semibold hover:bg-emerald-100/10 hover:border-emerald-900/20"
+            onClick={() => setOpenedDropDownType("order")}
           >
-            <Label
-              htmlFor="includedKeyword"
-              styles="text-15 text-slate-700 font-semibold flex-shrink-0 hover:text-emerald-900/80"
-            >
-              포함
-            </Label>
-            <input
-              type="text"
-              id="includedKeyword"
-              value={inputValue.includedKeyword}
-              onChange={(e) => handleFilterInputChange(e, "includedKeyword")}
-              className="w-full flex-grow-1 h-full px-10 font-semibold outline-none"
-              placeholder="포함할 키워드"
-            />
-          </form>
-          <div className="flex items-center w-full h-full">
-            {tempFilterList?.includedKeyword?.map((subKeyword) => {
-              return (
-                <KeywordChip
-                  key={subKeyword}
-                  keywordName={subKeyword}
-                  hasCloseButton={true}
-                  onClick={() => handleFilterChipRemoveButtonClick("includedKeyword", subKeyword)}
-                  styles="px-10 py-5 m-5 border-solid border-2 rounded-xl bg-green-100 border-green-200"
-                />
-              );
-            })}
+            {POST_LISTS.ORDER_KR[tempFilterList.order]}
+          </Button>
+          <Button
+            styles="w-110 right-20 px-5 py-4 rounded-[5px] font-medium text-gray-900/80 border-2 border-slate-200/80 font-semibold hover:bg-emerald-100/10 hover:border-emerald-900/20"
+            onClick={() => setOpenedDropDownType("keyword-included")}
+          >
+            {`키워드  ${keywordFilterCount}`}
+          </Button>
+          <Button
+            styles="w-110 right-20 px-5 py-4 rounded-[5px] font-medium text-gray-900/80 border-2 border-slate-200/80 font-semibold hover:bg-emerald-100/10 hover:border-emerald-900/20"
+            onClick={() => setOpenedDropDownType("ad")}
+          >
+            {getSelectedAdFilter(tempFilterList.isAd)}
+          </Button>
+          <Button
+            onClick={handleAllFilterApplyButtonClick}
+            styles="w-100 right-20 px-5 py-4 rounded-[5px] font-medium text-gray-900/80 border-2 border-slate-200/80 font-semibold hover:bg-emerald-100/10 hover:border-emerald-900/20 bg-green-100"
+          >
+            적용
+          </Button>
+        </ul>
+        {openedDropDownType === "order" && (
+          <div className="flex flex-col absolute w-170 top-40 p-15 gap-10 border-2 rounded-[5px] bg-white">
+            <div>
+              <span className="text-16 font-semibold">정렬</span>
+            </div>
+            <ul>
+              <li ref={dropDownBoxTextRef}>
+                <Button
+                  styles=""
+                  onClick={() => handleOrderDropDownClick(POST_LISTS.ORDER_EN.NEWEST)}
+                >
+                  <span>{POST_LISTS.ORDER_KR.NEWEST}</span>
+                </Button>
+              </li>
+              <li ref={dropDownBoxTextRef}>
+                <Button
+                  styles=""
+                  onClick={() => handleOrderDropDownClick(POST_LISTS.ORDER_EN.LIKE)}
+                >
+                  <span>{POST_LISTS.ORDER_KR.LIKE}</span>
+                </Button>
+              </li>
+              <li ref={dropDownBoxTextRef}>
+                <Button
+                  styles=""
+                  onClick={() => handleOrderDropDownClick(POST_LISTS.ORDER_EN.COMMENT)}
+                >
+                  <span>{POST_LISTS.ORDER_KR.COMMENT}</span>
+                </Button>
+              </li>
+            </ul>
           </div>
-        </div>
+        )}
+        {openedDropDownType.includes("keyword") && (
+          <div
+            ref={dropDownBoxTextRef}
+            className="flex flex-col absolute left-120 top-40 p-15 gap-10 w-400 border-2 rounded-[5px] bg-white"
+          >
+            <div>
+              <span className="text-16 font-semibold">키워드 필터</span>
+            </div>
+            <div className="flex flex-row gap-20 p-1 w-full h-40 rounded-lg bg-gray-100">
+              <Button
+                styles={`flex-1 p-5 m-1 round-md ${openedDropDownType === "keyword-included" && "bg-white"}`}
+                onClick={() => setOpenedDropDownType("keyword-included")}
+              >
+                <span>{POST_LISTS.INCLUDED_KEYWORD}</span>
+              </Button>
+              <Button
+                styles={`flex-1 p-5 m-1 round-md ${openedDropDownType !== "keyword-included" && "bg-white"}`}
+                onClick={() => setOpenedDropDownType("keyword-excluded")}
+              >
+                <span>{POST_LISTS.EXCLUDED_KEYWORD}</span>
+              </Button>
+            </div>
+            <form
+              className="w-full h-40 flex items-center gap-5 flex-shrink-0 border-2"
+              onSubmit={(e) =>
+                handleCreateTempKeywordFilterSubmit(e, selectedKeywordTypeInDropDownEN)
+              }
+            >
+              <Label
+                htmlFor={selectedKeywordTypeInDropDownEN}
+                styles="text-15 text-slate-700 font-semibold flex-shrink-0 hover:text-emerald-900/80"
+              ></Label>
+              <input
+                type="text"
+                id={selectedKeywordTypeInDropDownEN}
+                value={inputValue[selectedKeywordTypeInDropDownEN]}
+                onChange={(e) => handleKeywordFilterInputChange(e, selectedKeywordTypeInDropDownEN)}
+                className="w-full flex-grow-1 h-full px-10 font-semibold outline-none"
+                placeholder={selectedKeywordTypeInDropDownKR}
+              />
+            </form>
+            <ul>
+              <div className="flex flex-wrap w-full h-full">
+                {tempFilterList[selectedKeywordTypeInDropDownEN]?.map((keyword) => {
+                  return (
+                    <KeywordChip
+                      key={keyword}
+                      keywordName={keyword}
+                      hasCloseButton={true}
+                      onClick={() =>
+                        handleKeywordFilterChipRemoveButtonClick(
+                          selectedKeywordTypeInDropDownEN,
+                          keyword
+                        )
+                      }
+                      styles={`w-fit px-10 py-5 m-5 border-solid border-2 rounded-xl ${openedDropDownType === "keyword-included" ? "bg-green-100 border-green-200" : "bg-red-100 border-red-200"}`}
+                    />
+                  );
+                })}
+              </div>
+            </ul>
+          </div>
+        )}
+        {openedDropDownType === "ad" && (
+          <div
+            ref={dropDownBoxTextRef}
+            className="flex flex-col absolute left-240 top-40 w-170 p-15 gap-10 border-2 rounded-[5px] bg-white"
+          >
+            <div>
+              <span className="text-16 font-semibold">광고 필터</span>
+            </div>
+            <ul className="flex flex-col gap-10">
+              <li className="p-5 rounded-md hover:bg-green-100">
+                <Button
+                  styles=""
+                  onClick={() => handleAdFilterDropDownClick(POST_LISTS.ISAD_EN.ALL)}
+                >
+                  <span>{POST_LISTS.ISAD_KR.ALL}</span>
+                </Button>
+              </li>
+              <li className="p-5 rounded-md hover:bg-green-100">
+                <Button
+                  styles=""
+                  onClick={() => handleAdFilterDropDownClick(POST_LISTS.ISAD_EN.ONLY_ADS)}
+                >
+                  <span>{POST_LISTS.ISAD_KR.ONLY_ADS}</span>
+                </Button>
+              </li>
+              <li className="p-5 rounded-md hover:bg-green-100">
+                <Button
+                  styles=""
+                  onClick={() => handleAdFilterDropDownClick(POST_LISTS.ISAD_EN.NO_ADS)}
+                >
+                  <span>{POST_LISTS.ISAD_KR.NO_ADS}</span>
+                </Button>
+              </li>
+            </ul>
+          </div>
+        )}
+      </div>
+      <div className="flex flex-col gap-5">
+        <div className="flex items-center gap-15 w-full"></div>
         <p className="text-14 text-red-400 font-semibold">{errorMessage.includedKeyword}</p>
       </div>
-      <div className="flex flex-col gap-5">
-        <div className="flex items-center gap-15 w-full">
-          <form
-            className="w-400 h-40 px-20 flex items-center gap-5 flex-shrink-0 border-2 rounded-md"
-            onSubmit={(e) => handleCreateTempFilterSubmit(e, "excludedKeyword")}
-          >
-            <Label
-              htmlFor="excludedKeyword"
-              styles="text-15 text-slate-700 font-semibold flex-shrink-0 hover:text-emerald-900/80"
-            >
-              제외
-            </Label>
-            <input
-              type="text"
-              id="excludedKeyword"
-              value={inputValue.excludedKeyword}
-              onChange={(e) => handleFilterInputChange(e, "excludedKeyword")}
-              className="w-full flex-grow-1 h-full px-10 font-semibold outline-none"
-              placeholder="제외할 키워드"
-            />
-          </form>
-          <div className="flex items-center w-full h-full">
-            {tempFilterList?.excludedKeyword?.map((subKeyword) => {
-              return (
-                <KeywordChip
-                  key={subKeyword}
-                  keywordName={subKeyword}
-                  hasCloseButton={true}
-                  onClick={() => handleFilterChipRemoveButtonClick("excludedKeyword", subKeyword)}
-                  styles="px-10 py-3 m-5 border-solid border-2 rounded-xl bg-red-100 border-red-200"
-                />
-              );
-            })}
-          </div>
-        </div>
-        <p className="text-14 text-red-400 font-semibold">{errorMessage.excludedKeyword}</p>
-      </div>
-      <Button
-        onClick={handleFilterApplyButtonClick}
-        styles="w-200 right-20 px-50 py-5 rounded-[5px] font-medium text-gray-900/80 border-2 border-slate-200/80 font-semibold hover:bg-emerald-100/10 hover:border-emerald-900/20"
-      >
-        필터 적용
-      </Button>
+      <p className="text-14 text-red-400 font-semibold">{errorMessage.excludedKeyword}</p>
     </div>
   );
 };
@@ -171,8 +311,10 @@ export default PostListFilter;
 
 PostListFilter.propTypes = {
   filterList: PropTypes.shape({
-    includedKeyword: PropTypes.array.isRequired,
-    excludedKeyword: PropTypes.array.isRequired,
+    order: PropTypes.string.isRequired,
+    includedKeyword: PropTypes.arrayOf(PropTypes.string.isRequired),
+    excludedKeyword: PropTypes.arrayOf(PropTypes.string.isRequired),
+    isAd: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]).isRequired,
   }),
   setFilterList: PropTypes.func.isRequired,
 };

--- a/src/components/Card/Post/PostListFilter.jsx
+++ b/src/components/Card/Post/PostListFilter.jsx
@@ -1,12 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { useEffect, useMemo, useRef, useState } from "react";
 
 import { ERROR_MESSAGE, POST_LISTS } from "../../../config/constants";
-import { ERROR_MESSAGE, POST_LISTS } from "../../../config/constants";
 import KeywordChip from "../../Chip/KeywordChip";
-import FilterIcon from "../../Icon/FilterIcon";
-import ResetIcon from "../../Icon/ResetIcon";
-import SortIcon from "../../Icon/SortIcon";
 import FilterIcon from "../../Icon/FilterIcon";
 import ResetIcon from "../../Icon/ResetIcon";
 import SortIcon from "../../Icon/SortIcon";
@@ -14,16 +9,6 @@ import Button from "../../UI/Button";
 import Label from "../../UI/Label";
 import PropTypes from "prop-types";
 
-const PostListFilter = ({ filterList, setFilterList, resetFilterList }) => {
-  const syncedFilterList = useMemo(() => {
-    return {
-      order: filterList.order,
-      includedKeyword: filterList.includedKeyword,
-      excludedKeyword: filterList.excludedKeyword,
-      isAd: filterList.isAd,
-    };
-  }, [filterList.order, filterList.includedKeyword, filterList.excludedKeyword, filterList.isAd]);
-  const [tempFilterList, setTempFilterList] = useState(syncedFilterList);
 const PostListFilter = ({ filterList, setFilterList, resetFilterList }) => {
   const syncedFilterList = useMemo(() => {
     return {
@@ -123,7 +108,6 @@ const PostListFilter = ({ filterList, setFilterList, resetFilterList }) => {
     return;
   };
   const handleKeywordCreateTempFilterSubmit = (e, keywordFilterType) => {
-  const handleKeywordCreateTempFilterSubmit = (e, keywordFilterType) => {
     e.preventDefault();
     const trimmedInputValue = inputValue[keywordFilterType].trim();
 
@@ -144,7 +128,6 @@ const PostListFilter = ({ filterList, setFilterList, resetFilterList }) => {
       setErrorMessage((prev) => ({
         ...prev,
         [keywordFilterType]: ERROR_MESSAGE.KEYWORD_DUPLICATED_INPUT_VALUE,
-        [keywordFilterType]: ERROR_MESSAGE.KEYWORD_DUPLICATED_INPUT_VALUE,
       }));
       return;
     }
@@ -152,15 +135,11 @@ const PostListFilter = ({ filterList, setFilterList, resetFilterList }) => {
     setTempFilterList((prev) => ({
       ...prev,
       [keywordFilterType]: [...prev[keywordFilterType], trimmedInputValue],
-      [keywordFilterType]: [...prev[keywordFilterType], trimmedInputValue],
     }));
-    setInputValue((prev) => ({ ...prev, [keywordFilterType]: "" }));
-    setErrorMessage((prev) => ({ ...prev, [keywordFilterType]: "" }));
     setInputValue((prev) => ({ ...prev, [keywordFilterType]: "" }));
     setErrorMessage((prev) => ({ ...prev, [keywordFilterType]: "" }));
     return;
   };
-  const handleKeywordFilterChipRemoveButtonClick = (keywordFilterType, keywordFilterForRemove) => {
   const handleKeywordFilterChipRemoveButtonClick = (keywordFilterType, keywordFilterForRemove) => {
     setTempFilterList((prev) => ({
       ...prev,

--- a/src/components/Card/Post/PostListFilter.jsx
+++ b/src/components/Card/Post/PostListFilter.jsx
@@ -26,6 +26,7 @@ const PostListFilter = ({ filterList, setFilterList, resetFilterList }) => {
   const [errorMessage, setErrorMessage] = useState({
     includedKeyword: "",
     excludedKeyword: "",
+    filterApllied: "",
   });
   const [dropDownOpened, setDropDownOpened] = useState({
     isOpen: false,
@@ -65,11 +66,7 @@ const PostListFilter = ({ filterList, setFilterList, resetFilterList }) => {
     const tempFilters = Object.values(tempFilterList).flat().sort();
     const isEqualFilter = tempFilters.every((filter, index) => filter === filters[index]);
 
-    if (isEqualFilter) {
-      return true;
-    }
-
-    return false;
+    return isEqualFilter;
   };
 
   useEffect(() => {
@@ -181,20 +178,28 @@ const PostListFilter = ({ filterList, setFilterList, resetFilterList }) => {
     return;
   };
   const handleAllFilterListsApplyButtonClick = () => {
-    if (!vaildateEqualOriginalAndTempFilter) {
+    if (vaildateEqualOriginalAndTempFilter()) {
+      setErrorMessage((prev) => ({
+        ...prev,
+        filterApllied: ERROR_MESSAGE.APPLIED_POST_FILTER,
+      }));
       return;
     }
 
     setFilterList(tempFilterList);
+    setErrorMessage((prev) => ({
+      ...prev,
+      filterApllied: "",
+    }));
     return;
   };
   const handleAllFilterListsResetButtonClick = () => {
-    if (!vaildateEqualOriginalAndTempFilter) {
-      return;
-    }
-
     resetFilterList();
     setTempFilterList(syncedFilterList);
+    setErrorMessage((prev) => ({
+      ...prev,
+      filterApllied: "",
+    }));
     return;
   };
 
@@ -245,6 +250,9 @@ const PostListFilter = ({ filterList, setFilterList, resetFilterList }) => {
             <ResetIcon />
             <span className="text-12 text-gray-400">초기화</span>
           </Button>
+          <div className="px-10 flex-center">
+            <span className="font-light text-green-600">{errorMessage.filterApllied}</span>
+          </div>
         </ul>
         {dropDownOpened.dropDownType === "order" && (
           <div
@@ -324,7 +332,7 @@ const PostListFilter = ({ filterList, setFilterList, resetFilterList }) => {
               />
             </form>
             <div className="flex flex-col gap-5">
-              <p className="text-14 text-red-400 font-semibold">
+              <p className="text-14 text-red-400 font-light">
                 {errorMessage[selectedKeywordTypeInDropDownEN]}
               </p>
             </div>

--- a/src/components/Icon/CheckIcon.jsx
+++ b/src/components/Icon/CheckIcon.jsx
@@ -1,0 +1,17 @@
+const CheckIcon = ({ ...props }) => {
+  return (
+    <svg width="20px" height="20px" viewBox="0 0 24 24" {...props}>
+      <path
+        d="m4.5 12.75 6 6 9-13.5"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className="size-6"
+      ></path>
+    </svg>
+  );
+};
+
+export default CheckIcon;

--- a/src/components/Icon/FilterIcon.jsx
+++ b/src/components/Icon/FilterIcon.jsx
@@ -1,0 +1,17 @@
+const FilterIcon = ({ ...props }) => {
+  return (
+    <svg width="15px" height="15px" viewBox="0 0 25 25" className="flex items-center" {...props}>
+      <path
+        d="M12 3c2.755 0 5.455.232 8.083.678.533.09.917.556.917 1.096v1.044a2.25 2.25 0 0 1-.659 1.591l-5.432 5.432a2.25 2.25 0 0 0-.659 1.591v2.927a2.25 2.25 0 0 1-1.244 2.013L9.75 21v-6.568a2.25 2.25 0 0 0-.659-1.591L3.659 7.409A2.25 2.25 0 0 1 3 5.818V4.774c0-.54.384-1.006.917-1.096A48.32 48.32 0 0 1 12 3Z"
+        fill="none"
+        stroke="#64748b"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className="size-6"
+      ></path>
+    </svg>
+  );
+};
+
+export default FilterIcon;

--- a/src/components/Icon/ResetIcon.jsx
+++ b/src/components/Icon/ResetIcon.jsx
@@ -1,0 +1,17 @@
+const ResetIcon = ({ ...props }) => {
+  return (
+    <svg width="15px" height="15px" viewBox="0 0 24 24" {...props}>
+      <path
+        d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99"
+        fill="none"
+        stroke="#BDBDBD"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className="size-6"
+      ></path>
+    </svg>
+  );
+};
+
+export default ResetIcon;

--- a/src/components/Icon/SortIcon.jsx
+++ b/src/components/Icon/SortIcon.jsx
@@ -1,0 +1,17 @@
+const SortIcon = ({ ...props }) => {
+  return (
+    <svg width="15px" height="15px" viewBox="0 0 25 25" className="flex items-center" {...props}>
+      <path
+        d="M3.75 6.75h16.5M3.75 12h16.5M12 17.25h8.25"
+        fill="none"
+        stroke="#64748b"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className="size-6"
+      ></path>
+    </svg>
+  );
+};
+
+export default SortIcon;

--- a/src/components/UI/Label.jsx
+++ b/src/components/UI/Label.jsx
@@ -12,6 +12,6 @@ export default Label;
 
 Label.propTypes = {
   htmlFor: PropTypes.string.isRequired,
-  children: PropTypes.node.isRequired,
+  children: PropTypes.node,
   styles: PropTypes.string,
 };

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -31,10 +31,32 @@ export const PERIOD_TYPE = Object.freeze({
 });
 
 export const POST_LISTS = Object.freeze({
+  ORDER_KR: {
+    NEWEST: "최신 순",
+    LIKE: "공감 많은 순",
+    COMMENT: "댓글 많은 순",
+  },
+  ORDER_EN: {
+    NEWEST: "NEWEST",
+    LIKE: "LIKE",
+    COMMENT: "COMMENT",
+  },
   INCLUDED_KEYWORD: "포함할 키워드",
   EXCLUDED_KEYWORD: "제외할 키워드",
+  ISAD_KR: {
+    ALL: "광고 포함",
+    ONLY_ADS: "광고만",
+    NO_ADS: "광고 제외",
+  },
+  ISAD_EN: {
+    ALL: "",
+    ONLY_ADS: true,
+    NO_ADS: false,
+  },
+  DEFAULT_ORDER: "NEWEST",
   DEFAULT_INCLUDED_KEYWORD: [],
   DEFAULT_EXCLUDED_KEYWORD: [],
+  DEFAULT_IS_AD: "",
   DEFAULT_LIMIT: 10,
   DEFAULT_CURSOR_ID: "",
 });

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -17,6 +17,7 @@ export const ERROR_MESSAGE = Object.freeze({
   KEYWORD_EMPTY_INPUT_VALUE: "키워드를 입력해주세요.",
   CREATE_KEYWORD_ERROR: "새로운 키워드 생성에 실패하였습니다.",
   KEYWORD_DUPLICATED_INPUT_VALUE: "이미 키워드가 필터로 등록되어 있어요.",
+  APPLIED_POST_FILTER: "이미 필터가 적용되었어요.",
   SIGN_IN_ERROR: "로그인에 실패하였습니다.",
   FETCH_POSTS: "블로그 정보를 불러오지 못했습니다.",
 });

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -31,6 +31,8 @@ export const PERIOD_TYPE = Object.freeze({
 });
 
 export const POST_LISTS = Object.freeze({
+  INCLUDED_KEYWORD: "포함할 키워드",
+  EXCLUDED_KEYWORD: "제외할 키워드",
   DEFAULT_INCLUDED_KEYWORD: [],
   DEFAULT_EXCLUDED_KEYWORD: [],
   DEFAULT_LIMIT: 10,

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -57,6 +57,12 @@ export const POST_LISTS = Object.freeze({
   DEFAULT_INCLUDED_KEYWORD: [],
   DEFAULT_EXCLUDED_KEYWORD: [],
   DEFAULT_IS_AD: "",
+  DEFAULT_FILTER_LIST: {
+    order: "NEWEST",
+    includedKeyword: [],
+    excludedKeyword: [],
+    isAd: "",
+  },
   DEFAULT_LIMIT: 10,
   DEFAULT_CURSOR_ID: "",
 });

--- a/src/pages/KeywordPage.jsx
+++ b/src/pages/KeywordPage.jsx
@@ -8,7 +8,6 @@ import PeriodPostCountCard from "../components/Card/Chart/PeriodPostCountCard";
 import PeriodPostLikeCard from "../components/Card/Chart/PeriodPostLikeCard";
 import TodayPostCountCard from "../components/Card/Chart/TodayPostCountCard";
 import PostCardList from "../components/Card/Post/PostCardList";
-import PostListFilter from "../components/Card/Post/PostListFilter";
 import DashboardHeader from "../components/Header/DashboardHeader";
 import DashboardSidebar from "../components/Sidebar/DashboardSidebar";
 import { POST_LISTS } from "../config/constants";
@@ -22,7 +21,6 @@ const KeywordPage = () => {
   const { groupId, keywordId } = useParams();
   const [dashboardType, setDashboardType] = useState("chart");
   const [filterList, setFilterList] = useState(POST_LISTS.DEFAULT_FILTER_LIST);
-  const [hasPost, setHasPost] = useState(false);
   const setUserGroupList = useBoundStore((state) => state.setUserGroupList);
   const userUid = useBoundStore((state) => state.userInfo.uid);
   const hasUserUid = !!userUid;
@@ -32,7 +30,9 @@ const KeywordPage = () => {
   };
 
   useEffect(() => {
-    resetFilterList();
+    if (keywordId) {
+      resetFilterList();
+    }
   }, [keywordId]);
 
   const { data: userGroupList, isError: isUserGroupListError } = useQuery({
@@ -109,17 +109,11 @@ const KeywordPage = () => {
                 </div>
               ) : (
                 <div className="flex flex-col h-full">
-                  {!hasPost && (
-                    <PostListFilter
-                      filterList={filterList}
-                      setFilterList={setFilterList}
-                      resetFilterList={resetFilterList}
-                    />
-                  )}
                   <PostCardList
                     keywordId={keywordId}
                     filterList={filterList}
-                    setHasPost={setHasPost}
+                    setFilterList={setFilterList}
+                    resetFilterList={resetFilterList}
                   />
                 </div>
               )}

--- a/src/pages/KeywordPage.jsx
+++ b/src/pages/KeywordPage.jsx
@@ -109,7 +109,7 @@ const KeywordPage = () => {
                 </div>
               ) : (
                 <div className="flex flex-col h-full">
-                  {hasPost && (
+                  {!hasPost && (
                     <PostListFilter
                       filterList={filterList}
                       setFilterList={setFilterList}

--- a/src/pages/KeywordPage.jsx
+++ b/src/pages/KeywordPage.jsx
@@ -11,6 +11,7 @@ import PostCardList from "../components/Card/Post/PostCardList";
 import PostListFilter from "../components/Card/Post/PostListFilter";
 import DashboardHeader from "../components/Header/DashboardHeader";
 import DashboardSidebar from "../components/Sidebar/DashboardSidebar";
+import { POST_LISTS } from "../config/constants";
 import useNoSignInRedirect from "../hooks/useNoSignInRedirect";
 import useBoundStore from "../store/client/useBoundStore";
 import { useQuery } from "@tanstack/react-query";
@@ -21,10 +22,10 @@ const KeywordPage = () => {
   const { groupId, keywordId } = useParams();
   const [dashboardType, setDashboardType] = useState("chart");
   const [filterList, setFilterList] = useState({
-    order: "",
-    includedKeyword: [],
-    excludedKeyword: [],
-    isAd: "",
+    order: POST_LISTS.DEFAULT_ORDER,
+    includedKeyword: POST_LISTS.DEFAULT_INCLUDED_KEYWORD,
+    excludedKeyword: POST_LISTS.DEFAULT_EXCLUDED_KEYWORD,
+    isAd: POST_LISTS.DEFAULT_IS_AD,
   });
   const setUserGroupList = useBoundStore((state) => state.setUserGroupList);
   const userUid = useBoundStore((state) => state.userInfo.uid);
@@ -33,10 +34,10 @@ const KeywordPage = () => {
 
   useEffect(() => {
     setFilterList(() => ({
-      order: "",
-      includedKeyword: [],
-      excludedKeyword: [],
-      isAd: "",
+      order: POST_LISTS.DEFAULT_ORDER,
+      includedKeyword: POST_LISTS.DEFAULT_INCLUDED_KEYWORD,
+      excludedKeyword: POST_LISTS.DEFAULT_EXCLUDED_KEYWORD,
+      isAd: POST_LISTS.DEFAULT_IS_AD,
     }));
   }, [keywordId, setFilterList]);
 

--- a/src/pages/KeywordPage.jsx
+++ b/src/pages/KeywordPage.jsx
@@ -12,7 +12,6 @@ import PostListFilter from "../components/Card/Post/PostListFilter";
 import DashboardHeader from "../components/Header/DashboardHeader";
 import DashboardSidebar from "../components/Sidebar/DashboardSidebar";
 import { POST_LISTS } from "../config/constants";
-import { POST_LISTS } from "../config/constants";
 import useNoSignInRedirect from "../hooks/useNoSignInRedirect";
 import useBoundStore from "../store/client/useBoundStore";
 import { useQuery } from "@tanstack/react-query";
@@ -31,13 +30,8 @@ const KeywordPage = () => {
   const resetFilterList = () => {
     setFilterList(POST_LISTS.DEFAULT_FILTER_LIST);
   };
-  const resetFilterList = () => {
-    setFilterList(POST_LISTS.DEFAULT_FILTER_LIST);
-  };
 
   useEffect(() => {
-    resetFilterList();
-  }, [keywordId]);
     resetFilterList();
   }, [keywordId]);
 

--- a/src/pages/KeywordPage.jsx
+++ b/src/pages/KeywordPage.jsx
@@ -21,8 +21,10 @@ const KeywordPage = () => {
   const { groupId, keywordId } = useParams();
   const [dashboardType, setDashboardType] = useState("chart");
   const [filterList, setFilterList] = useState({
+    order: "",
     includedKeyword: [],
     excludedKeyword: [],
+    isAd: "",
   });
   const setUserGroupList = useBoundStore((state) => state.setUserGroupList);
   const userUid = useBoundStore((state) => state.userInfo.uid);
@@ -31,8 +33,10 @@ const KeywordPage = () => {
 
   useEffect(() => {
     setFilterList(() => ({
+      order: "",
       includedKeyword: [],
       excludedKeyword: [],
+      isAd: "",
     }));
   }, [keywordId, setFilterList]);
 

--- a/src/pages/KeywordPage.jsx
+++ b/src/pages/KeywordPage.jsx
@@ -22,6 +22,7 @@ const KeywordPage = () => {
   const { groupId, keywordId } = useParams();
   const [dashboardType, setDashboardType] = useState("chart");
   const [filterList, setFilterList] = useState(POST_LISTS.DEFAULT_FILTER_LIST);
+  const [hasPost, setHasPost] = useState(false);
   const setUserGroupList = useBoundStore((state) => state.setUserGroupList);
   const userUid = useBoundStore((state) => state.userInfo.uid);
   const hasUserUid = !!userUid;
@@ -108,12 +109,18 @@ const KeywordPage = () => {
                 </div>
               ) : (
                 <div className="flex flex-col h-full">
-                  <PostListFilter
+                  {hasPost && (
+                    <PostListFilter
+                      filterList={filterList}
+                      setFilterList={setFilterList}
+                      resetFilterList={resetFilterList}
+                    />
+                  )}
+                  <PostCardList
+                    keywordId={keywordId}
                     filterList={filterList}
-                    setFilterList={setFilterList}
-                    resetFilterList={resetFilterList}
+                    setHasPost={setHasPost}
                   />
-                  <PostCardList keywordId={keywordId} filterList={filterList} />
                 </div>
               )}
             </>

--- a/src/pages/KeywordPage.jsx
+++ b/src/pages/KeywordPage.jsx
@@ -21,25 +21,18 @@ const KeywordPage = () => {
 
   const { groupId, keywordId } = useParams();
   const [dashboardType, setDashboardType] = useState("chart");
-  const [filterList, setFilterList] = useState({
-    order: POST_LISTS.DEFAULT_ORDER,
-    includedKeyword: POST_LISTS.DEFAULT_INCLUDED_KEYWORD,
-    excludedKeyword: POST_LISTS.DEFAULT_EXCLUDED_KEYWORD,
-    isAd: POST_LISTS.DEFAULT_IS_AD,
-  });
+  const [filterList, setFilterList] = useState(POST_LISTS.DEFAULT_FILTER_LIST);
   const setUserGroupList = useBoundStore((state) => state.setUserGroupList);
   const userUid = useBoundStore((state) => state.userInfo.uid);
   const hasUserUid = !!userUid;
   const hasKeywordId = !!keywordId;
+  const resetFilterList = () => {
+    setFilterList(POST_LISTS.DEFAULT_FILTER_LIST);
+  };
 
   useEffect(() => {
-    setFilterList(() => ({
-      order: POST_LISTS.DEFAULT_ORDER,
-      includedKeyword: POST_LISTS.DEFAULT_INCLUDED_KEYWORD,
-      excludedKeyword: POST_LISTS.DEFAULT_EXCLUDED_KEYWORD,
-      isAd: POST_LISTS.DEFAULT_IS_AD,
-    }));
-  }, [keywordId, setFilterList]);
+    resetFilterList();
+  }, [keywordId]);
 
   const { data: userGroupList, isError: isUserGroupListError } = useQuery({
     queryKey: ["userGroupList", userUid],
@@ -115,7 +108,11 @@ const KeywordPage = () => {
                 </div>
               ) : (
                 <div className="flex flex-col h-full">
-                  <PostListFilter filterList={filterList} setFilterList={setFilterList} />
+                  <PostListFilter
+                    filterList={filterList}
+                    setFilterList={setFilterList}
+                    resetFilterList={resetFilterList}
+                  />
                   <PostCardList keywordId={keywordId} filterList={filterList} />
                 </div>
               )}


### PR DESCRIPTION
## 이슈

- close #34 

## 구현 화면

![Screen Recording 2024-11-18 at 3 46 02 AM](https://github.com/user-attachments/assets/a8b97320-885e-40bf-93d6-f60f95fe5dfa)


## 상세 설명

> 게시물 정렬 및 필터링 UI를 구현했습니다.

#### 기능 개요
- 정렬: 최신 순(default) / 공감 많은 순 / 댓글 많은 순
- 필터 - 키워드: 포함 키워드, 제외 키워드 (변동 없음)
- 필터 - 광고: 광고 포함(default) / 광고만 / 광고 제외

#### 드롭다운
- 드롭다운의 일반적인 동작을 구현했습니다.
   - 드롭다운 내 버튼 혹은 드롭다운 외부 클릭시 꺼짐, 그외 드롭다운 내부 클릭시 드롭다운 열림 유지

#### 정렬/필터 초기화
- 설정한 필터는 수동으로 초기화 가능하며, 다른 키워드 대시보드간 이동시에도 자동 초기화 됩니다. ([관련 이전 PR의 코드 리뷰](https://github.com/Team-Bloblow/Bloblow-Client/pull/31#pullrequestreview-2440285026))

#### 그외 세부사항
- 게시물 없을 시, 게시물 카드가 노출되지 않으며 필터 UI도 함께 표기되지 않습니다.
- 동일한 필터가 적용이 이미 되어있을 경우 에러 메시지 ([관련 이전 PR의 코드 리뷰](https://github.com/Team-Bloblow/Bloblow-Client/pull/31#discussion_r1844901197))

## 참고사항

- 현재는 기존 포함/제외 키워드 필터링 외에 UX 검토만 가능하며, 이어서 작업할 백엔드 API 구현 후 최종 테스트 진행 예정입니다.
- 추후 `PostListFilter` 컴포넌트를 쪼개어서, 유지보수가 더 쉽고 가독성이 좋은 코드로 리팩토링 가능하겠습니다.
- 드롭다운 UI 구현시 `useDropDown` 커스텀 훅을 사용하지 않았습니다.
   - 현재 해당 커스텀 훅의 의도, 쓰임새(여닫음 조건 등)가 다르고, 간단하게 구현할 수 있을 것이라 보고 별도로 구현했습니다.

#### 테스트 브랜치
1. Client: `feat/post-postListFilter-UI`
2. Server: `dev`

## PR 체크 사항

- [ ] conflict를 모두 해결하였습니다.
- [ ] 가장 최신 dev 브랜치를 pull 하였습니다.
- [ ] 코드 컨벤션을 모두 확인하였습니다.
- [ ] `console.log`나 주석 여부를 확인하였습니다.
- [ ] 브랜치명을 확인하였습니다.
- [ ] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!
- [ ] `API 명세서`를 확인하였으며 동기화 하였습니다.

## 리뷰 반영사항

-

## 리뷰 마감요청시간
- 2024년 11월 18일 오후 6시