### PR TITLE
Fix: 구독 해지 버튼 원복

### DIFF
--- a/src/components/Header/DashboardHeader.jsx
+++ b/src/components/Header/DashboardHeader.jsx
@@ -1,6 +1,8 @@
 import { useState } from "react";
 
 import asyncPutGroupName from "../../api/group/asyncPutGroupName";
+import AlertModal from "../../components/Modal/AlertModal";
+import ConfirmModal from "../../components/Modal/ConfirmModal";
 import { ALERT_MESSAGE, CONFIRM_MESSAGE, ERROR_MESSAGE, MODAL_TYPE } from "../../config/constants";
 import useBoundStore from "../../store/client/useBoundStore";
 import getDate from "../../utils/getDate";
@@ -8,8 +10,6 @@ import KeywordChip from "../Chip/KeywordChip";
 import CalendarIcon from "../Icon/CalendarIcon";
 import EditIcon from "../Icon/EditIcon";
 import UpdateIcon from "../Icon/UpdateIcon";
-import AlertModal from "../Modal/AlertModal";
-import ConfirmModal from "../Modal/ConfirmModal";
 import ErrorModal from "../Modal/ErrorModal";
 import Button from "../UI/Button";
 import Label from "../UI/Label";
@@ -17,6 +17,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import PropTypes from "prop-types";
 
 const DashboardHeader = ({ userGroupList, userUid, groupId, specificKeywordData, keywordId }) => {
+  const addModal = useBoundStore((state) => state.addModal);
   const openModalTypeList = useBoundStore((state) => state.openModalTypeList);
   const dashboardGroup = userGroupList?.find((groupInfo) => groupInfo._id === groupId);
   const dashboardGroupName = dashboardGroup?.name;
@@ -48,6 +49,10 @@ const DashboardHeader = ({ userGroupList, userUid, groupId, specificKeywordData,
 
   const createdDate = getDate(specificKeywordData?.createdAt);
   const updatedDate = getDate(specificKeywordData?.updatedAt);
+
+  const handleKeywordDelete = async () => {
+    addModal(MODAL_TYPE.CONFIRM);
+  };
 
   if (keywordId === undefined) {
     const handleEditGroupButtonClick = () => {
@@ -149,6 +154,12 @@ const DashboardHeader = ({ userGroupList, userUid, groupId, specificKeywordData,
           <span className="flex items-center pt-2">
             <CalendarIcon className="size-18 fill-none mr-5 font-bold" />
             {`구독 시작일 : ${createdDate?.currentYear}년 ${createdDate?.currentMonth}월 ${createdDate?.currentDate}일`}
+            <Button
+              styles="w-70 h-40 rounded-[4px] text-slate-500 item-center text-center text-15 font-medium ml-4 underline decoration-1"
+              onClick={handleKeywordDelete}
+            >
+              구독 해지
+            </Button>
           </span>
           <span className="flex items-center pt-2">
             <UpdateIcon className="size-18 mr-5" />


### PR DESCRIPTION
## 구현 화면
![스크린샷 2024-11-22 오후 2 10 19](https://github.com/user-attachments/assets/6a1af14f-8923-4276-a5af-32c4142a041a)


## 상세 설명

- [키워드 구독 해지에 대한 server 이슈](https://github.com/Team-Bloblow/Bloblow-Server/pull/60) 발생으로 삭제시킨 구독 해지 버튼을 해당 이슈 해결되어 원복시켰습니다.


## 참고사항

- #50 과 동일한 로직입니다.


## PR 체크 사항

- [x] conflict를 모두 해결하였습니다.
- [x] 가장 최신 dev 브랜치를 pull 하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] `console.log`나 주석 여부를 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
- [x] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!
- [x] `API 명세서`를 확인하였으며 동기화 하였습니다.

## 리뷰 반영사항

- 2024년 11월 22일 22시까지
