### PR TITLE
Feat: 최근 업데이트 그룹의 키워드별 게시물 수 조회 UI 구현

### DIFF
--- a/src/api/group/asyncGetGroupSummary.js
+++ b/src/api/group/asyncGetGroupSummary.js
@@ -1,0 +1,16 @@
+import fetchHandler from "..";
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+
+const asyncGetGroupSummary = async (userUid) => {
+  const fetchInfo = {
+    url: `${API_BASE_URL}/groups/${userUid}/summary`,
+    params: "",
+  };
+
+  const response = await fetchHandler(fetchInfo);
+
+  return response;
+};
+
+export default asyncGetGroupSummary;

--- a/src/components/Card/UserGroup/UserGroupCard.jsx
+++ b/src/components/Card/UserGroup/UserGroupCard.jsx
@@ -11,13 +11,13 @@ const UserGroupCard = ({ groupId, groupName, keywordList, updatedAt }) => {
   return (
     <Link to={`/dashboard/${groupId}`}>
       <div className="flex flex-col items-start justify-center gap-7 w-full border-2 border-slate-200/80 bg-white rounded-[5px] px-30 py-12 shadow-sm hover:border-emerald-900/30 hover:shadow-md">
-        <p className="flex items-center tex-green-900 text-20 font-semibold">{groupName}</p>
+        <p className="flex items-center text-black text-20 font-semibold">{groupName}</p>
         <div className="flex items-center gap-5 w-full mb-2">
           {keywordList.map((keyword) => (
             <KeywordChip
               key={keyword._id}
               keywordName={"# " + keyword.keyword}
-              styles="flex-center text-17 px-7 py-3 bg-green-500/10 text-black rounded-[3px]"
+              styles="flex-center text-15 px-7 py-3 bg-green-500/10 text-black rounded-[3px]"
             />
           ))}
         </div>

--- a/src/components/Card/UserGroup/UserGroupCardList.jsx
+++ b/src/components/Card/UserGroup/UserGroupCardList.jsx
@@ -1,3 +1,5 @@
+import { useEffect } from "react";
+
 import asyncGetUserGroup from "../../../api/group/asyncGetUserGroup";
 import useBoundStore from "../../../store/client/useBoundStore";
 import UserGroupCard from "./UserGroupCard";
@@ -14,6 +16,12 @@ const UserGroupCardList = () => {
     enabled: hasUserUid,
   });
 
+  useEffect(() => {
+    if (hasUserUid && userGroupList?.groupListResult?.length > 0) {
+      setUserGroupList(userGroupList?.groupListResult);
+    }
+  }, [hasUserUid, userGroupList?.groupListResult, setUserGroupList]);
+
   if (isError || userGroupList?.message?.includes("Error occured")) {
     return (
       <div className="flex flex-center w-full h-full">
@@ -24,10 +32,6 @@ const UserGroupCardList = () => {
 
   if (userGroupList?.groupListLength === 0) {
     return <div className="flex flex-center w-full h-full">생성한 그룹이 없습니다</div>;
-  }
-
-  if (hasUserUid && userGroupList?.groupListResult?.length > 0) {
-    setUserGroupList(userGroupList?.groupListResult);
   }
 
   return (

--- a/src/components/Sidebar/GroupSummary.jsx
+++ b/src/components/Sidebar/GroupSummary.jsx
@@ -1,16 +1,18 @@
 import useBoundStore from "../../store/client/useBoundStore";
+import getDateDiff from "../../utils/getDateDiff";
 
 const GroupSummary = () => {
   const userGroupList = useBoundStore((state) => state.userGroupList);
   const groupLatestUpdated = userGroupList.reduce((prev, curr) => {
     return new Date(prev.updatedAt) <= new Date(curr.updatedAt) ? curr : prev;
   });
+  const passedDate = getDateDiff("today", groupLatestUpdated.updatedAt);
 
   return (
     <div className="flex flex-col gap-20 w-full h-full px-15 lg:px-15 py-10 lg:py-15">
       <div className="flex justify-between items-end">
         <span className="text-20 font-semibold">최근 업데이트</span>
-        <span className="text-12 font-light text-gray-500">3일전</span>
+        <span className="text-12 font-light text-gray-500">{passedDate}일 전</span>
       </div>
       <div className="flex justify-between">
         <span className="text-17 font-light text-gray-600">그룹</span>

--- a/src/components/Sidebar/GroupSummary.jsx
+++ b/src/components/Sidebar/GroupSummary.jsx
@@ -16,7 +16,7 @@ const GroupSummary = () => {
       </div>
       <div className="flex justify-between">
         <span className="text-17 font-light text-gray-600">그룹</span>
-        <span className="text-17 font-semibold">그룹 이름</span>
+        <span className="text-17 font-semibold">{groupLatestUpdated.name}</span>
       </div>
       <div className="flex justify-between">
         <span className="text-15 font-light text-gray-600">키워드명</span>

--- a/src/components/Sidebar/GroupSummary.jsx
+++ b/src/components/Sidebar/GroupSummary.jsx
@@ -1,0 +1,20 @@
+const GroupSummary = () => {
+  return (
+    <div className="flex flex-col gap-20 w-full h-full px-15 lg:px-15 py-10 lg:py-15">
+      <div className="flex justify-between items-end">
+        <span className="text-20 font-semibold">최근 업데이트</span>
+        <span className="text-12 font-light text-gray-500">3일전</span>
+      </div>
+      <div className="flex justify-between">
+        <span className="text-17 font-light text-gray-600">그룹</span>
+        <span className="text-17 font-semibold">그룹 이름</span>
+      </div>
+      <div className="flex justify-between">
+        <span className="text-15 font-light text-gray-600">키워드명</span>
+        <span className="text-15 font-light text-gray-600">게시물 수</span>
+      </div>
+    </div>
+  );
+};
+
+export default GroupSummary;

--- a/src/components/Sidebar/GroupSummary.jsx
+++ b/src/components/Sidebar/GroupSummary.jsx
@@ -1,4 +1,11 @@
+import useBoundStore from "../../store/client/useBoundStore";
+
 const GroupSummary = () => {
+  const userGroupList = useBoundStore((state) => state.userGroupList);
+  const groupLatestUpdated = userGroupList.reduce((prev, curr) => {
+    return new Date(prev.updatedAt) <= new Date(curr.updatedAt) ? curr : prev;
+  });
+
   return (
     <div className="flex flex-col gap-20 w-full h-full px-15 lg:px-15 py-10 lg:py-15">
       <div className="flex justify-between items-end">

--- a/src/components/Sidebar/GroupSummary.jsx
+++ b/src/components/Sidebar/GroupSummary.jsx
@@ -1,33 +1,68 @@
+import asyncGetGroupSummary from "../../api/group/asyncGet\bGroupSummary";
 import useBoundStore from "../../store/client/useBoundStore";
 import getDateDiff from "../../utils/getDateDiff";
+import { useQuery } from "@tanstack/react-query";
 
 const GroupSummary = () => {
-  const userGroupList = useBoundStore((state) => state.userGroupList);
-  const groupLatestUpdated =
-    userGroupList.length === 0
-      ? {}
-      : userGroupList?.reduce((prev, curr) => {
-          return new Date(prev.updatedAt) <= new Date(curr.updatedAt) ? curr : prev;
-        });
-  const passedDate = getDateDiff("today", groupLatestUpdated.updatedAt);
+  const userUid = useBoundStore((state) => state.userInfo.uid);
+
+  const {
+    data: summaryData,
+    isError: summaryDataError,
+    isPending: summaryDataPending,
+  } = useQuery({
+    queryKey: ["lastUpdateGroupSummary", userUid],
+    queryFn: () => asyncGetGroupSummary(userUid),
+    enabled: !!userUid,
+    staleTime: 5 * 1000,
+  });
+
+  const isError = summaryDataError || summaryData?.message?.includes("Error occured");
+  const passedDate = getDateDiff("today", summaryData?.lastUpdatedAt);
+
+  if (isError) {
+    return (
+      <div className="flex flex-col gap-20 w-full h-full px-15 lg:px-15 py-10 lg:py-15">
+        <span className="text-12 font-light text-gray-600">
+          최근 업데이트를 불러오는데 실패했습니다. 잠시 후에 다시 시도해주세요.
+        </span>
+      </div>
+    );
+  }
+
+  if (summaryDataPending) {
+    return null;
+  }
 
   return (
     <div className="flex flex-col gap-20 w-full h-full px-15 lg:px-15 py-10 lg:py-15">
       <div className="flex justify-between items-end">
         <span className="text-20 font-semibold">최근 업데이트</span>
-        <span className="text-12 font-light text-gray-500">
-          {passedDate ? `${passedDate}일 전` : null}
-        </span>
+        {passedDate && <span className="text-12 font-light text-gray-500">{passedDate}일 전</span>}
       </div>
-      <div className="flex justify-between">
-        <span className="text-17 font-light text-gray-600">그룹</span>
-        <span className="text-17 font-semibold">
-          {groupLatestUpdated.name ? groupLatestUpdated.name : "-"}
-        </span>
+      <div className="flex flex-col gap-10">
+        <span className="text-15 font-light text-gray-600">그룹</span>
+        {summaryData?.group && (
+          <span className="text-17 font-medium">
+            {summaryData?.group.length > 15
+              ? summaryData?.group.substring(0, 14) + "..."
+              : summaryData?.group}
+          </span>
+        )}
       </div>
       <div className="flex justify-between">
         <span className="text-15 font-light text-gray-600">키워드명</span>
         <span className="text-15 font-light text-gray-600">게시물 수</span>
+      </div>
+      <div>
+        {summaryData?.postUpdateNewest?.map((keyword) => {
+          return (
+            <div key={keyword.id} className="flex justify-between">
+              <span className="text-17 font-medium">{keyword.name}</span>
+              <span className="text-17 font-medium">{keyword.postCount}</span>
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/components/Sidebar/GroupSummary.jsx
+++ b/src/components/Sidebar/GroupSummary.jsx
@@ -3,20 +3,27 @@ import getDateDiff from "../../utils/getDateDiff";
 
 const GroupSummary = () => {
   const userGroupList = useBoundStore((state) => state.userGroupList);
-  const groupLatestUpdated = userGroupList.reduce((prev, curr) => {
-    return new Date(prev.updatedAt) <= new Date(curr.updatedAt) ? curr : prev;
-  });
+  const groupLatestUpdated =
+    userGroupList.length === 0
+      ? {}
+      : userGroupList?.reduce((prev, curr) => {
+          return new Date(prev.updatedAt) <= new Date(curr.updatedAt) ? curr : prev;
+        });
   const passedDate = getDateDiff("today", groupLatestUpdated.updatedAt);
 
   return (
     <div className="flex flex-col gap-20 w-full h-full px-15 lg:px-15 py-10 lg:py-15">
       <div className="flex justify-between items-end">
         <span className="text-20 font-semibold">최근 업데이트</span>
-        <span className="text-12 font-light text-gray-500">{passedDate}일 전</span>
+        <span className="text-12 font-light text-gray-500">
+          {passedDate ? `${passedDate}일 전` : null}
+        </span>
       </div>
       <div className="flex justify-between">
         <span className="text-17 font-light text-gray-600">그룹</span>
-        <span className="text-17 font-semibold">{groupLatestUpdated.name}</span>
+        <span className="text-17 font-semibold">
+          {groupLatestUpdated.name ? groupLatestUpdated.name : "-"}
+        </span>
       </div>
       <div className="flex justify-between">
         <span className="text-15 font-light text-gray-600">키워드명</span>

--- a/src/components/Sidebar/MyPageSidebar.jsx
+++ b/src/components/Sidebar/MyPageSidebar.jsx
@@ -4,6 +4,7 @@ import CreateKeywordModal from "../Modal/CreateKeywordModal";
 import CreateKeywordSuccessModal from "../Modal/CreateKeywordSuccessModal";
 import ErrorModal from "../Modal/ErrorModal";
 import Button from "../UI/Button";
+import GroupSummary from "./GroupSummary";
 
 const MyPageSidebar = () => {
   const addModal = useBoundStore((state) => state.addModal);
@@ -15,7 +16,9 @@ const MyPageSidebar = () => {
 
   return (
     <aside className="flex gap-20 w-full px-30 lg:px-0 lg:w-fit lg:flex-col">
-      <div className="flex lg:flex-col items-center gap-25 w-full lg:w-220 h-100 lg:h-320 px-30 lg:px-30 py-10 lg:py-20 rounded-[8px] bg-white border-2 border-slate-200/80 flex-grow lg:flex-grow-0 shadow-sm"></div>
+      <div className="flex lg:flex-col items-center gap-25 w-full lg:w-220 lg:h-fit rounded-[8px] bg-white border-2 border-slate-200/80 flex-grow lg:flex-grow-0 shadow-sm">
+        <GroupSummary />
+      </div>
       <Button
         styles="w-300 lg:w-full px-10 lg:px-20 lg:py-18 text-21 text-gray-900/80 font-bold border-2 border-slate-200/80 rounded-[8px] shadow-sm hover:shadow-md hover:bg-emerald-200/10 hover:border-emerald-900/30"
         onClick={handleCreateKeywordButton}

--- a/src/pages/GroupPage.jsx
+++ b/src/pages/GroupPage.jsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
 import asyncGetUserGroup from "../api/group/asyncGetUserGroup";
@@ -30,6 +31,12 @@ const GroupPage = () => {
     (groupInfo) => groupInfo._id === groupId
   );
 
+  useEffect(() => {
+    if (userGroupList?.groupListLength > 0 && userGroupList?.groupListResult?.length > 0) {
+      setUserGroupList(userGroupList?.groupListResult);
+    }
+  }, [userGroupList?.groupListLength, userGroupList?.groupListResult, setUserGroupList]);
+
   if (invalidGroupId === undefined) {
     navigate("/notFoundPage");
     return;
@@ -47,10 +54,6 @@ const GroupPage = () => {
 
   if (userGroupList === undefined) {
     return null;
-  }
-
-  if (userGroupList?.groupListLength > 0 && userGroupList?.groupListResult?.length > 0) {
-    setUserGroupList(userGroupList?.groupListResult);
   }
 
   return (

--- a/src/utils/getDateDiff.js
+++ b/src/utils/getDateDiff.js
@@ -1,0 +1,13 @@
+const getDateDiff = (dateStr, dateComparedStr) => {
+  if (typeof dateStr !== "string" || typeof dateComparedStr !== "string") {
+    return null;
+  }
+
+  const date = dateStr === "today" ? new Date() : new Date(dateStr);
+  const dateCompared = new Date(dateComparedStr);
+  const dateDiff = date.getTime() - dateCompared.getTime();
+
+  return Math.ceil(dateDiff / (1000 * 60 * 60 * 24));
+};
+
+export default getDateDiff;


### PR DESCRIPTION
## 이슈

- close #56 
- 참고 서버 PR [링크](https://github.com/Team-Bloblow/Bloblow-Server/pull/68)

## 구현 화면
<image width="500" src="https://github.com/user-attachments/assets/e04978a0-3420-4d81-9c52-6dc60218be15">

## 상세 설명

- 유저 로그인 시 MyPage 좌측 사이드바에서 최근 업데이트된 그룹의 게시물 수 현황을 조회할 수 있습니다.
- 유저의 가장 마지막 생성된 게시물의 `createdAt`을 기준으로 최근 업데이트 그룹을 판별합니다.

## 참고사항

- 그룹과 키워드 관계를 인지할 수 있도록 의도했습니다. 유저 첫 진입시 샘플 그룹 데이터가 최근 업데이트 그룹으로 집계됩니다.
- apporve가 되면 현재 [PR 리뷰](https://github.com/Team-Bloblow/Bloblow-Server/pull/68) 중인 서버 브랜치와 함께 머지 진행하겠습니다.
- 별도 라이브러리는 설치하지 않았습니다.


## PR 체크 사항

- [ ] conflict를 모두 해결하였습니다.
- [ ] 가장 최신 dev 브랜치를 pull 하였습니다.
- [ ] 코드 컨벤션을 모두 확인하였습니다.
- [ ] `console.log`나 주석 여부를 확인하였습니다.
- [ ] 브랜치명을 확인하였습니다.
- [ ] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!
- [ ] `API 명세서`를 확인하였으며 동기화 하였습니다.

## 리뷰 반영사항

-
