### PR TITLE
Fix: scrollY가 0이상일 경우, layout shift가 일어나는 현상 디버깅

### DIFF
--- a/src/hooks/useScrollDisable.js
+++ b/src/hooks/useScrollDisable.js
@@ -3,19 +3,20 @@ import { useEffect } from "react";
 const useScrollDisable = () => {
   useEffect(() => {
     const scrollY = window.scrollY;
+    const hasScroll = document.documentElement.scrollHeight > document.documentElement.clientHeight;
 
-    if (scrollY > 0) {
-      document.body.style.cssText = `
-        position: fixed;
-        top: -${scrollY}px;
-        overflow-y: scroll;
-      `;
+    document.body.style.cssText = `
+      position: fixed;
+      top: -${scrollY}px;
+      left: 0;
+      right: 0;
+      ${hasScroll && "overflow-y: scroll;"}
+    `;
 
-      return () => {
-        document.body.style.cssText = "";
-        window.scrollTo(0, scrollY);
-      };
-    }
+    return () => {
+      document.body.style.cssText = "";
+      window.scrollTo(0, scrollY);
+    };
   }, []);
 };
 


### PR DESCRIPTION
## 이슈

- close #57 

## 상세 설명

- 모달이 마운트 되었을 경우, `position: fixed`인 상태에서 left/right 값을 설정해주지 않았기에 body 태그가 중앙 정렬 되어 있는 경우, layout shift가 일어났습니다. 해당 내용 디버깅하였습니다.

## 참고사항

- 위의 내용 참고 부탁드립니다.

## PR 체크 사항

- [ ] conflict를 모두 해결하였습니다.
- [ ] 가장 최신 dev 브랜치를 pull 하였습니다.
- [ ] 코드 컨벤션을 모두 확인하였습니다.
- [ ] `console.log`나 주석 여부를 확인하였습니다.
- [ ] 브랜치명을 확인하였습니다.
- [ ] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!
- [ ] `API 명세서`를 확인하였으며 동기화 하였습니다.

## 리뷰 반영사항

-
