### PR TITLE
Fix: 무한 스크롤이 작동되지 않고 한번에 모든 데이터 불러와지는 이슈 해결

### DIFF
--- a/src/components/Card/Post/PostCardList.jsx
+++ b/src/components/Card/Post/PostCardList.jsx
@@ -11,7 +11,6 @@ import PropTypes from "prop-types";
 
 const PostCardList = ({ keywordId, filterList, setFilterList, resetFilterList }) => {
   const observeRef = useRef(null);
-  const observeRootRef = useRef(null);
 
   const infiniteDataArgument = {
     queryKey: ["posts", keywordId, filterList],
@@ -27,10 +26,14 @@ const PostCardList = ({ keywordId, filterList, setFilterList, resetFilterList })
     initialPageParam: "",
     getNextPageParam: (lastPage) => (lastPage.hasNext ? lastPage.nextCursorId : undefined),
     ref: observeRef,
-    root: observeRootRef.current,
   };
 
-  const { data: postResponse, isPending, isError } = useInfiniteData(infiniteDataArgument);
+  const {
+    data: postResponse,
+    isPending,
+    isFetchingNextPage,
+    isError,
+  } = useInfiniteData(infiniteDataArgument);
   const hasNotPostResponseForFirstRequest =
     filterList === POST_LISTS.DEFAULT_FILTER_LIST && postResponse?.pages[0]?.items?.length === 0;
   const hasPostResponse = postResponse?.pages[0]?.items?.length > 0;
@@ -52,47 +55,39 @@ const PostCardList = ({ keywordId, filterList, setFilterList, resetFilterList })
   }
 
   return (
-    <article
-      ref={observeRootRef}
-      className={`flex flex-col gap-12 bg-white p-10 w-full min-h-730 overflow-y-scroll`}
-    >
-      {isPending ? (
-        <Loading width={100} height={100} text={""} />
-      ) : (
-        <>
-          <PostListFilter
-            keywordId={keywordId}
-            filterList={filterList}
-            setFilterList={setFilterList}
-            resetFilterList={resetFilterList}
-          />
-          <div
-            className={`${hasPostResponse ? "flex flex-col gap-10" : "flex-col-center w-full h-full flex-grow"}`}
-          >
-            {hasPostResponse ? (
-              postResponse?.pages?.map((page) => {
-                return page.items?.map((postInfo) => {
-                  return (
-                    <PostCard
-                      key={postInfo?._id}
-                      postTitle={postInfo?.title}
-                      postDescription={postInfo?.description}
-                      likeCount={postInfo?.likeCount}
-                      commentCount={postInfo?.commentCount}
-                      link={postInfo?.link}
-                      createdAt={postInfo?.createdAt}
-                      isAd={postInfo?.isAd ?? false}
-                    />
-                  );
-                });
-              })
-            ) : (
-              <p className="text-22">확인할 수 있는 게시물이 없어요</p>
-            )}
-          </div>
-        </>
-      )}
-      <div ref={observeRef} />
+    <article className={`flex flex-col gap-12 bg-white p-10 w-full min-h-730 overflow-y-scroll`}>
+      <PostListFilter
+        keywordId={keywordId}
+        filterList={filterList}
+        setFilterList={setFilterList}
+        resetFilterList={resetFilterList}
+      />
+      <div
+        className={`${hasPostResponse ? "flex flex-col w-full h-full gap-10" : "flex-col-center w-full h-full flex-grow"}`}
+      >
+        {hasPostResponse ? (
+          postResponse?.pages?.map((page) => {
+            return page.items?.map((postInfo) => {
+              return (
+                <PostCard
+                  key={postInfo?._id}
+                  postTitle={postInfo?.title}
+                  postDescription={postInfo?.description}
+                  likeCount={postInfo?.likeCount}
+                  commentCount={postInfo?.commentCount}
+                  link={postInfo?.link}
+                  createdAt={postInfo?.createdAt}
+                  isAd={postInfo?.isAd ?? false}
+                />
+              );
+            });
+          })
+        ) : (
+          <p className="text-22">확인할 수 있는 게시물이 없어요</p>
+        )}
+        {isFetchingNextPage && <Loading width={50} height={50} text={""} />}
+      </div>
+      <div ref={observeRef} className="h-1" />
     </article>
   );
 };

--- a/src/components/Card/Post/PostCardList.jsx
+++ b/src/components/Card/Post/PostCardList.jsx
@@ -65,27 +65,33 @@ const PostCardList = ({ keywordId, filterList, setFilterList, resetFilterList })
       <div
         className={`${hasPostResponse ? "flex flex-col w-full h-full gap-10" : "flex-col-center w-full h-full flex-grow"}`}
       >
-        {hasPostResponse ? (
-          postResponse?.pages?.map((page) => {
-            return page.items?.map((postInfo) => {
-              return (
-                <PostCard
-                  key={postInfo?._id}
-                  postTitle={postInfo?.title}
-                  postDescription={postInfo?.description}
-                  likeCount={postInfo?.likeCount}
-                  commentCount={postInfo?.commentCount}
-                  link={postInfo?.link}
-                  createdAt={postInfo?.createdAt}
-                  isAd={postInfo?.isAd ?? false}
-                />
-              );
-            });
-          })
+        {isPending ? (
+          <Loading width={100} height={100} text={""} />
         ) : (
-          <p className="text-22">확인할 수 있는 게시물이 없어요</p>
+          <>
+            {hasPostResponse ? (
+              postResponse?.pages?.map((page) => {
+                return page.items?.map((postInfo) => {
+                  return (
+                    <PostCard
+                      key={postInfo?._id}
+                      postTitle={postInfo?.title}
+                      postDescription={postInfo?.description}
+                      likeCount={postInfo?.likeCount}
+                      commentCount={postInfo?.commentCount}
+                      link={postInfo?.link}
+                      createdAt={postInfo?.createdAt}
+                      isAd={postInfo?.isAd ?? false}
+                    />
+                  );
+                });
+              })
+            ) : (
+              <p className="text-22">확인할 수 있는 게시물이 없어요</p>
+            )}
+            {isFetchingNextPage && <Loading width={50} height={50} text={""} />}
+          </>
         )}
-        {isFetchingNextPage && <Loading width={50} height={50} text={""} />}
       </div>
       <div ref={observeRef} className="h-1" />
     </article>

--- a/src/components/Card/Post/PostListFilter.jsx
+++ b/src/components/Card/Post/PostListFilter.jsx
@@ -61,6 +61,7 @@ const PostListFilter = ({ keywordId, filterList, setFilterList, resetFilterList 
         return POST_LISTS.IS_AD_KR.NO_ADS;
     }
   };
+
   const vaildateEqualOriginalAndTempFilter = () => {
     const filters = Object.values(filterList).flat().sort();
     const tempFilters = Object.values(tempFilterList).flat().sort();
@@ -68,7 +69,7 @@ const PostListFilter = ({ keywordId, filterList, setFilterList, resetFilterList 
     if (filters.length !== tempFilters.length) {
       return false;
     }
-    const isEqualFilter = tempFilters.every((filter, index) => filter === filters[index]); // 완전 동일해야 하는데 지금은 포함하면 통과됨.
+    const isEqualFilter = tempFilters.every((filter, index) => filter === filters[index]);
 
     return isEqualFilter;
   };

--- a/src/hooks/useInfiniteData.js
+++ b/src/hooks/useInfiniteData.js
@@ -8,15 +8,14 @@ const useInfiniteData = ({
   initialPageParam,
   getNextPageParam,
   ref,
-  root,
 }) => {
-  const { data, status, fetchNextPage, isPending, isError, ...rest } = useInfiniteQuery({
-    queryKey,
-    queryFn: ({ pageParam }) => queryFn(pageParam, options),
-    initialPageParam,
-    getNextPageParam,
-    staleTime: 10 * 1000,
-  });
+  const { data, status, fetchNextPage, isPending, isFetchingNextPage, isError, ...rest } =
+    useInfiniteQuery({
+      queryKey,
+      queryFn: ({ pageParam }) => queryFn(pageParam, options),
+      initialPageParam,
+      getNextPageParam,
+    });
 
   const onIntersect = (entries) => {
     if (isPending) return;
@@ -29,9 +28,9 @@ const useInfiniteData = ({
     });
   };
 
-  useObserver({ target: ref, root, threshold: 0.5, onIntersect });
+  useObserver({ target: ref, threshold: 1.0, onIntersect });
 
-  return { data, status, fetchNextPage, isPending, isError, ...rest };
+  return { data, status, fetchNextPage, isPending, isError, isFetchingNextPage, ...rest };
 };
 
 export default useInfiniteData;


### PR DESCRIPTION
## 이슈

- close #65 

## 상세 설명

- 기존에 UI를 수정하면서 observeRootRef를 삭제했어야 했는데, 삭제하지 않아서 무한 스크롤의 `fetchNextPage()`가 계속해서 동작한 것으로 원인 파악 => observeRootRef 삭제
- 기존의 `isPending` 로직에 따른 Loading UI 수정 => `isFetchingNextPage`의 값에 따른 Loading UI 렌더링으로 수정

## 참고사항

- 상세 설명 참고 부탁드립니다.

## PR 체크 사항

- [x] conflict를 모두 해결하였습니다.
- [x] 가장 최신 dev 브랜치를 pull 하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] `console.log`나 주석 여부를 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
- [x] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!
- [x] `API 명세서`를 확인하였으며 동기화 하였습니다.

## 리뷰 반영사항

-
