### PR TITLE
Feat: 로그인 인증 상태 지속성 local 기준 적용

### DIFF
--- a/src/components/Button/SignInButton.jsx
+++ b/src/components/Button/SignInButton.jsx
@@ -20,8 +20,6 @@ const SignInButton = ({ type }) => {
   const isSignIn = useBoundStore((state) => state.isSignIn);
   const asyncSignIn = useBoundStore((state) => state.asyncSignIn);
   const signOut = useBoundStore((state) => state.signOut);
-  const setIsSignIn = useBoundStore((state) => state.setIsSignIn);
-  const setUserInfo = useBoundStore((state) => state.setUserInfo);
   const openModalTypeList = useBoundStore((state) => state.openModalTypeList);
   const googleSignInError = useBoundStore((state) => state.authError.googleSignInError);
   const addModal = useBoundStore((state) => state.addModal);
@@ -49,10 +47,6 @@ const SignInButton = ({ type }) => {
               addModal(MODAL_TYPE.ERROR);
               return;
             }
-
-            const { uid, email, displayName, photoURL } = data.userResult;
-            setIsSignIn(true);
-            setUserInfo({ uid, email, displayName, photoURL });
             navigate("/myPage");
           },
           onError: () => {

--- a/src/components/Button/SignInButton.jsx
+++ b/src/components/Button/SignInButton.jsx
@@ -1,5 +1,3 @@
-import { useNavigate } from "react-router-dom";
-
 import asyncPostSignIn from "../../api/auth/asyncPostSignIn";
 import {
   ERROR_MESSAGE,
@@ -15,8 +13,6 @@ import { useMutation } from "@tanstack/react-query";
 import PropTypes from "prop-types";
 
 const SignInButton = ({ type }) => {
-  const navigate = useNavigate();
-
   const isSignIn = useBoundStore((state) => state.isSignIn);
   const asyncSignIn = useBoundStore((state) => state.asyncSignIn);
   const signOut = useBoundStore((state) => state.signOut);
@@ -47,7 +43,6 @@ const SignInButton = ({ type }) => {
               addModal(MODAL_TYPE.ERROR);
               return;
             }
-            navigate("/myPage");
           },
           onError: () => {
             addModal(MODAL_TYPE.ERROR);

--- a/src/components/Layout/Header.jsx
+++ b/src/components/Layout/Header.jsx
@@ -4,8 +4,9 @@ import useBoundStore from "../../store/client/useBoundStore";
 import SignInButton from "../Button/SignInButton";
 import Logo from "../Common/Logo";
 import ProfileIcon from "../Icon/ProfileIcon";
+import PropTypes from "prop-types";
 
-const Header = () => {
+const Header = ({ isAuthChecked }) => {
   const location = useLocation();
   const pathname = location.pathname;
   const userInfo = useBoundStore((state) => state.userInfo);
@@ -26,7 +27,7 @@ const Header = () => {
               <p className="text-15 font-semibold">{userInfo.displayName}</p>
             </div>
           )}
-          <SignInButton />
+          {isAuthChecked && <SignInButton />}
         </div>
       </div>
     </header>
@@ -34,3 +35,7 @@ const Header = () => {
 };
 
 export default Header;
+
+Header.propTypes = {
+  isAuthChecked: PropTypes.bool.isRequired,
+};

--- a/src/pages/App.jsx
+++ b/src/pages/App.jsx
@@ -39,7 +39,7 @@ const App = () => {
 
   return (
     <ReactQueryProviders>
-      <Header />
+      <Header isAuthChecked={isAuthChecked} />
       {isAuthChecked ? (
         <Routes>
           <Route path="/" exact element={<HomePage />} />

--- a/src/pages/App.jsx
+++ b/src/pages/App.jsx
@@ -1,28 +1,62 @@
+import { useEffect, useState } from "react";
 import { Route, Routes } from "react-router-dom";
 
 import Header from "../components/Layout/Header";
+import Loading from "../components/UI/Loading";
 import ReactQueryProviders from "../config/ReactQueryProvider";
+import useBoundStore from "../store/client/useBoundStore";
 import GroupPage from "./GroupPage";
 import HomePage from "./HomePage";
 import KeywordPage from "./KeywordPage";
 import MyPage from "./MyPage";
 import NotFoundPage from "./NotFoundPage";
+import { getAuth, onAuthStateChanged } from "firebase/auth";
 
 const App = () => {
+  const setIsSignIn = useBoundStore((state) => state.setIsSignIn);
+  const setUserInfo = useBoundStore((state) => state.setUserInfo);
+  const signOut = useBoundStore((state) => state.signOut);
+  const [isAuthChecked, setIsAuthChecked] = useState(false);
+
+  useEffect(() => {
+    const auth = getAuth();
+    const unsubscribe = onAuthStateChanged(auth, (user) => {
+      if (user) {
+        const uid = user.uid;
+        const { email, displayName, photoUrl: photoURL } = user.reloadUserInfo;
+
+        setIsSignIn(true);
+        setUserInfo({ uid, email, displayName, photoURL });
+        setIsAuthChecked(true);
+      } else {
+        signOut();
+        setIsAuthChecked(true);
+      }
+    });
+
+    return () => unsubscribe();
+  }, [setIsSignIn, setUserInfo, signOut]);
+
   return (
     <ReactQueryProviders>
       <Header />
-      <Routes>
-        <Route path="/" exact element={<HomePage />} />
-        <Route path="/myPage" element={<MyPage />} />
-        <Route path="/dashboard">
-          <Route path=":groupId">
-            <Route index element={<GroupPage />} />
-            <Route path=":keywordId" element={<KeywordPage />} />
+      {isAuthChecked ? (
+        <Routes>
+          <Route path="/" exact element={<HomePage />} />
+          <Route path="/myPage" element={<MyPage />} />
+          <Route path="/dashboard">
+            <Route path=":groupId">
+              <Route index element={<GroupPage />} />
+              <Route path=":keywordId" element={<KeywordPage />} />
+            </Route>
           </Route>
-        </Route>
-        <Route path="*" element={<NotFoundPage />} />
-      </Routes>
+          <Route path="*" element={<NotFoundPage />} />
+        </Routes>
+      ) : (
+        <div className="flex h-screen w-screen mt-64 justify-center align-center">
+          <Loading width={60} height={60} text={""} />
+        </div>
+      )}
     </ReactQueryProviders>
   );
 };

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -2,11 +2,8 @@ import SignInButton from "../components/Button/SignInButton";
 import Logo from "../components/Common/Logo";
 import Footer from "../components/Layout/Footer";
 import { SIGN_BUTTON_TYPE } from "../config/constants";
-import useSignInRedirect from "../hooks/useSignInRedirect";
 
 const HomePage = () => {
-  useSignInRedirect();
-
   return (
     <main className="flex flex-col items-center w-full gap-20 overflow-y-scroll">
       <div className="w-full h-screen flex-grow-1 flex-center gap-30 p-50 bg-emerald-100/30">

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -2,8 +2,11 @@ import SignInButton from "../components/Button/SignInButton";
 import Logo from "../components/Common/Logo";
 import Footer from "../components/Layout/Footer";
 import { SIGN_BUTTON_TYPE } from "../config/constants";
+import useSignInRedirect from "../hooks/useSignInRedirect";
 
 const HomePage = () => {
+  useSignInRedirect();
+
   return (
     <main className="flex flex-col items-center w-full gap-20 overflow-y-scroll">
       <div className="w-full h-screen flex-grow-1 flex-center gap-30 p-50 bg-emerald-100/30">


### PR DESCRIPTION
## 이슈

- close #32 

## 구현 화면
[새로고침, 탭 전환시 사용자 인증 상태 유지]
<image width="500" src="https://github.com/user-attachments/assets/b381260c-bf3b-474f-8d99-3e5dea3f5d0f">

## 상세 설명

- Firebase `onAuthStateChanged` observer를 활용하여 새로고침, 탭 전환에도 사용자 인증 상태를 유지하도록 했습니다.
   - 참고 [Firebase `onAuthStateChanged`](https://firebase.google.com/docs/auth/web/manage-users?hl=ko#get_the_currently_signed-in_user)
- 특정 화면의 URL 복사 후 다른 탭에서 URL 붙여넣을 경우, 로그인 상태로 해당 화면에 진입 가능합니다.
- 사용자가 로그인 상태를 삭제하려면 명시적으로 로그아웃을 수행해야 합니다.
- 로그인 후 사용자 및 토큰 정보는 크롬 개발자 도구 Application 탭 아래 경로에서 확인할 수 있습니다.
   - IndexedDB > firebaseLocalStorageDb > firebaseLocalStorage

## 참고사항

- 테스트를 진행하실 경우, 최초 회원가입 유저 시나리오를 중심으로 봐주시면 감사하겠습니다.
- (1) 인증 상태에 따른 리다이렉트, (2) 유저 정보의 전역 상태 업데이트 역할을 모두 `App` 컴포넌트의 역할로 통일했습니다.
   - 이에 아래 수정사항이 발생했습니다.
   - 기존 `HomePage` 컴포넌트에서 사용했던 `useSignInRedirect` 훅 호출을 제거했습니다.
   - `SignInButton` 컴포넌트에서 로그인 요청에 대한 응답을 받고 전역 상태를 업데이트하는 로직을 제거했습니다.
   - (참고) `useSignInRedirect` 훅은 이제 `NotFoundPage` 컴포넌트에서만 활용됩니다.
- `App` 컴포넌트에 `isAuthChecked` 상태를 새롭게 선언하고, 로그인 인증 체크 완료까지 화면 처리를 위해 `Loading` 컴포넌트를 재사용했습니다. 아래 맥락을 참고해주시면 감사하겠습니다.
   - 기존에는 새로고침 시 항상 전역 상태의 `userInfo`가 초기화 되어 `HomePage` (랜딩페이지)로 이동했습니다.
   - 이번에 인증 상태 유지를 위해 `onAuthStateChanged` 옵저버를 `useEffect` 안에서 구독 설정하고, `App` 컴포넌트가 언마운트 될 때 구독을 해지하도록 구현했습니다.
   - 새로고침 시 `onAuthStateChanged` 옵저버의 콜백 함수로 현재 인증 상태를 평가합니다. 로그인, 로그아웃 여부가 확실히 판별되면 그제서야 의도대로 로그인 성공 유저를 `MyPage`로 이동시킵니다.
   - 이때 `useEffect`의 설정 함수가 렌더링 이후에 실행되므로 로그인 후에도 `HomePage` 컴포넌트가 잠시 UI에 표기되는 현상을 개선하고자 했습니다.
   - 인증 상태 평가가 끝나면 (이번에 새로 선언한) `isAuthChecked` 상태를 `true`로 업데이트 하고 `MyPage`로 이동합니다. 그 전에는 `Loading` 컴포넌트가 화면에 표시됩니다.
- 별도 라이브러리는 설치하지 않았습니다.

## 공유사항

- 샘플 데이터 추가 로직이 로그인 로직에 추가되면서 소요시간이 큰 폭으로 증가했는데 추후 개선이 필요합니다.
   - 로컬 환경에서 8회 가량 테스트 해보았을 때, 대체로 `signin` 응답이 5초 가량 소요되었습니다. 배포 환경에서는 이보다 줄어든 1-2초 소요되는 것으로 확인했습니다. 샘플 데이터 추가로 성능 이슈 고민을 하게 되었습니다. 
   - 앞으로 샘플 데이터가 더 쌓이면 그만큼 소요시간이 길어질 수 있고, 현재 제공하는 키워드, 게시물 양이 많거나 적지는 않은지 추후 함께 검토해보면 좋겠습니다.
   - 구조적으로 유저 마다 샘플 데이터를 개별로 쌓아주는 구조를 두고 있는데, 장기적으로는 샘플 데이터는 1개이고 모든 유저들이 중앙의 해당 샘플 데이터를 참조할 수 있는 구조도 고려해볼 수 있겠습니다.
   - (참고) `summary` 응답도 5-6초 가량 소요되어 해당 기능도 최적화가 필요하겠습니다. 

[로그인 `signin` 응답 처리시간]
<img width="200" alt="Screenshot 2024-12-29 at 5 35 23 PM" src="https://github.com/user-attachments/assets/11ebeaf9-adc3-4360-b418-4edfaf2c3670" />

[최근 업데이트 `summary` 응답 처리시간]
<image width="200" src="https://github.com/user-attachments/assets/cdab2793-5de4-4839-b9d9-eb57fa2aecb1">


## PR 체크 사항

- [ ] conflict를 모두 해결하였습니다.
- [ ] 가장 최신 dev 브랜치를 pull 하였습니다.
- [ ] 코드 컨벤션을 모두 확인하였습니다.
- [ ] `console.log`나 주석 여부를 확인하였습니다.
- [ ] 브랜치명을 확인하였습니다.
- [ ] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!
- [ ] `API 명세서`를 확인하였으며 동기화 하였습니다.

## 리뷰 반영사항

-
